### PR TITLE
Feature/no parameterless lambda signature

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -597,7 +597,7 @@ tryAgain:
         /// </summary>
         private bool IsPossibleSubpatternElement()
         {
-            return this.IsPossibleExpression(allowBinaryExpressions: false, allowAssignmentExpressions: false) ||
+            return this.IsPossibleExpression(allowBinaryExpressions: false, allowAssignmentExpressions: false, allowBraceLambdaExpression: false) ||
                 this.CurrentToken.Kind switch
                 {
                     SyntaxKind.OpenBraceToken => true,

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -122,6 +122,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return SyntaxToken.Create(kind, leading, trailing);
         }
 
+        internal static SyntaxToken FakeToken(SyntaxKind kind, string value = null, bool allowTrivia = false)
+        {
+            return SyntaxToken.CreateFake(kind, value, allowTrivia);
+        }
+
         internal static SyntaxToken Token(GreenNode leading, SyntaxKind kind, string text, string valueText, GreenNode trailing)
         {
             Debug.Assert(SyntaxFacts.IsAnyToken(kind));

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.MissingTokenWithTrivia.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.MissingTokenWithTrivia.cs
@@ -9,6 +9,67 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {
+        internal class FakeTokenWithTrivia : SyntaxTokenWithTrivia
+        {
+            private string _value;
+            private bool _allowTrivia;
+
+            internal FakeTokenWithTrivia(SyntaxKind kind, string value, bool allowTrivia)
+                : base(kind, null, null)
+            {
+                _value = value;
+                _allowTrivia = allowTrivia;
+            }
+
+            internal FakeTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing, string value, bool allowTrivia)
+                : base(kind, leading, trailing)
+            {
+                _value = value;
+                _allowTrivia = allowTrivia;
+            }
+
+            internal FakeTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, string value, bool allowTrivia)
+                : base(kind, leading, trailing, diagnostics, annotations)
+            {
+                _value = value;
+                _allowTrivia = allowTrivia;
+            }
+
+            internal FakeTokenWithTrivia(ObjectReader reader)
+                : base(reader)
+            {
+            }
+
+            static FakeTokenWithTrivia()
+            {
+                ObjectBinder.RegisterTypeReader(typeof(FakeTokenWithTrivia), r => new FakeTokenWithTrivia(r));
+            }
+
+            public override string Text => string.Empty;
+
+            public override object Value => _value;
+
+            public override SyntaxToken TokenWithLeadingTrivia(GreenNode trivia)
+            {
+                return new FakeTokenWithTrivia(this.Kind, _allowTrivia ? trivia : null, this.TrailingField, this.GetDiagnostics(), this.GetAnnotations(), _value, _allowTrivia);
+            }
+
+            public override SyntaxToken TokenWithTrailingTrivia(GreenNode trivia)
+            {
+                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, _allowTrivia ? trivia : null, this.GetDiagnostics(), this.GetAnnotations(), _value, _allowTrivia);
+            }
+
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            {
+                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, this.TrailingField, diagnostics, this.GetAnnotations(), _value, _allowTrivia);
+            }
+
+            internal override GreenNode SetAnnotations(SyntaxAnnotation[] annotations)
+            {
+                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, this.TrailingField, this.GetDiagnostics(), annotations, _value, _allowTrivia);
+            }
+        }
+
         internal class MissingTokenWithTrivia : SyntaxTokenWithTrivia
         {
             internal MissingTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing)

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
@@ -131,6 +131,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new SyntaxTokenWithTrivia(kind, leading, trailing);
         }
 
+        internal static SyntaxToken CreateFake(SyntaxKind kind, string value = null, bool allowTrivia = false)
+        {
+            return new FakeTokenWithTrivia(kind, value, allowTrivia);
+        }
+
         internal static SyntaxToken CreateMissing(SyntaxKind kind, GreenNode leading, GreenNode trailing)
         {
             return new MissingTokenWithTrivia(kind, leading, trailing);

--- a/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpParameterWrapper.cs
+++ b/src/Features/CSharp/Portable/Wrapping/SeparatedSyntaxList/CSharpParameterWrapper.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.CodeGeneration;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Utilities;
 using Roslyn.Utilities;
@@ -40,6 +41,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Wrapping.SeparatedSyntaxList
             if (declaration.Kind() == SyntaxKind.SimpleLambdaExpression)
             {
                 return false;
+            }
+            else if(declaration.Kind() == SyntaxKind.ParenthesizedLambdaExpression && listSyntax is ParameterListSyntax paramsListSyntax)
+            {
+                // If we have a fake parenthesis ... use the last token as t
+                if (paramsListSyntax.OpenParenToken.FullWidth() == 0 && paramsListSyntax.CloseParenToken.FullWidth() == 0)
+                {
+                    return false;
+                }
             }
 
             var generator = CSharpSyntaxGenerator.Instance;

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/NewLineUserSettingFormattingRule.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
@@ -205,6 +206,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             RoslynDebug.AssertNotNull(currentToken.Parent);
 
             var operation = nextOperation.Invoke(in previousToken, in currentToken);
+
+            if (currentToken.Width() == 0 || previousToken.Width() == 0) return null;
 
             // else condition is actually handled in the GetAdjustSpacesOperation()
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/SpacingFormattingRule.cs
@@ -12,6 +12,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting.Rules;
 using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
@@ -50,6 +51,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             var currentKind = currentToken.Kind();
             var previousParentKind = previousToken.Parent.Kind();
             var currentParentKind = currentToken.Parent.Kind();
+
+            if (previousToken.Width() == 0 || currentToken.Width() == 0) return null;
 
             // For Method Declaration
             if (currentToken.IsOpenParenInParameterList() && previousKind == SyntaxKind.IdentifierToken)

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/IndentBlockOperation.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/Core/Formatting/Rules/Operations/IndentBlockOperation.cs
@@ -35,6 +35,13 @@ namespace Microsoft.CodeAnalysis.Formatting.Rules
 
         internal IndentBlockOperation(SyntaxToken baseToken, SyntaxToken startToken, SyntaxToken endToken, TextSpan textSpan, int indentationDelta, IndentBlockOption option)
         {
+            // if we have gotten a span starting before the "base token" ... just adjust the span to start from there instead ...
+            if (textSpan.Start < baseToken.SpanStart) {
+                var diff = baseToken.SpanStart - textSpan.Start;
+                var newLength = textSpan.Length - diff;
+                textSpan = new TextSpan(baseToken.SpanStart, newLength);
+            }
+
             Contract.ThrowIfFalse(option.IsMaskOn(IndentBlockOption.PositionMask));
 
             Contract.ThrowIfFalse(option.IsMaskOn(IndentBlockOption.RelativePositionMask));


### PR DESCRIPTION
Adds support for parameterless lambda blocks syntax:

`
DoSomethingAndInvokeCallback({
  Console.WriteLine("This is an inline lambda without any parameters and no '() => {}' syntax");
})
`
