### PR TITLE
Feature/functions no return type

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -1426,6 +1426,12 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
         }
 
+        internal TypeWithAnnotations BindSpecialType(SyntaxKind typeKind, DiagnosticBag diagnostics = null, SyntaxNode node = null, bool isNullableEnabled = false)
+        {
+            var typeSymbol = GetSpecialType(typeKind.GetSpecialType(), diagnostics, node);
+            return TypeWithAnnotations.Create(isNullableEnabled, typeSymbol);
+        }
+
         internal NamedTypeSymbol GetSpecialType(SpecialType typeId, DiagnosticBag diagnostics, SyntaxNode node)
         {
             return GetSpecialType(this.Compilation, typeId, node, diagnostics);
@@ -1435,7 +1441,11 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             NamedTypeSymbol typeSymbol = compilation.GetSpecialType(typeId);
             Debug.Assert((object)typeSymbol != null, "Expect an error type if special type isn't found");
-            ReportUseSiteDiagnostics(typeSymbol, diagnostics, node);
+            // only report if there is actually a node with a location
+            if (node != null && diagnostics != null)
+            {
+                ReportUseSiteDiagnostics(typeSymbol, diagnostics, node);
+            }
             return typeSymbol;
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2281,9 +2281,7 @@ tryAgain:
                 TypeSyntax type;
                 bool hasExplicitType;
                 // Before parsing the return type, check if it looks like a method
-                if (this.CurrentToken.Kind == SyntaxKind.IdentifierToken &&
-                    // check if following is a "(" or a "<" ... then it's most likely the name we are at!
-                    (this.PeekToken(1).Kind == SyntaxKind.OpenParenToken || this.PeekToken(1).Kind == SyntaxKind.LessThanToken))
+                if (IsPossibleMethodDeclarationStart() || IsPossibleGetterPropertyDeclarationStart())
                 {
                     // it's more likely to be a method - without any return type defined
                     var token = SyntaxFactory.Token(SyntaxKind.IdentifierToken);
@@ -2676,11 +2674,7 @@ parse_member_name:;
                 // check if following is a "{ get " or a "{ set "
                 if(peeked1.Kind == SyntaxKind.OpenBraceToken)
                 {
-                    var peeked2 = this.PeekToken(2);
-                    if(peeked2.Kind == SyntaxKind.GetKeyword || peeked2.Kind == SyntaxKind.SetKeyword)
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
 
@@ -3536,8 +3530,8 @@ parse_member_name:;
                     var getAccessor = ParseAccessorDeclaration(isEvent: false, isGetterAccessor: true);
                     builder.Add(getAccessor);
                     var accessors = builder.ToList();
-                    var openBrace = SyntaxFactory.Token(SyntaxKind.OpenBraceToken);
-                    var closeBrace = SyntaxFactory.Token(SyntaxKind.CloseBraceToken);
+                    var openBrace = SyntaxFactory.FakeToken(SyntaxKind.OpenBraceToken, "{");
+                    var closeBrace = SyntaxFactory.FakeToken(SyntaxKind.CloseBraceToken, "}");
                     accessorList = _syntaxFactory.AccessorList(openBrace, accessors, closeBrace);
                 }
             }
@@ -3917,7 +3911,7 @@ parse_member_name:;
                     _pool.Free(attributes);
 
                     // this is explicitly defined as a getter ... so no "get" is needed... we will however set a fake name
-                    accessorName = SyntaxFactory.Token(SyntaxKind.GetKeyword);
+                    accessorName = SyntaxFactory.FakeToken(SyntaxKind.GetKeyword, "get");
                 }
 
                 var accessorKind = GetAccessorKind(accessorName);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/Helpers/CodeBlockExitPathsFinder.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/Helpers/CodeBlockExitPathsFinder.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols.Source.Helpers
+{
+    internal sealed class CodeBlockExitPathsFinder : BoundTreeWalker
+    {
+        internal static readonly TypeSymbol NoReturnExpression = new UnsupportedMetadataTypeSymbol();
+
+        private readonly ArrayBuilder<(BoundNode, TypeWithAnnotations)> _builder;
+
+        private CodeBlockExitPathsFinder(ArrayBuilder<(BoundNode, TypeWithAnnotations)> builder)
+        {
+            _builder = builder;
+        }
+
+        public static void GetExitPaths(ArrayBuilder<(BoundNode, TypeWithAnnotations)> builder, BoundNode node)
+        {
+            var visitor = new CodeBlockExitPathsFinder(builder);
+            visitor.Visit(node);
+        }
+
+        public override BoundNode Visit(BoundNode node)
+        {
+            if (!(node is BoundExpression))
+            {
+                return base.Visit(node);
+            }
+
+            return null;
+        }
+
+        protected override BoundExpression VisitExpressionWithoutStackGuard(BoundExpression node)
+        {
+            throw ExceptionUtilities.Unreachable;
+        }
+
+        public override BoundNode VisitLocalFunctionStatement(BoundLocalFunctionStatement node)
+        {
+            // Do not recurse into local functions; we don't want their returns.
+            return null;
+        }
+
+        public override BoundNode VisitReturnStatement(BoundReturnStatement node)
+        {
+            var expression = node.ExpressionOpt;
+            var type = (expression is null) ?
+                NoReturnExpression :
+                expression.Type?.SetUnknownNullabilityForReferenceTypes();
+            _builder.Add((node, TypeWithAnnotations.Create(type)));
+            return null;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -8,6 +8,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Threading;
 using Microsoft.Cci;
+using Microsoft.CodeAnalysis.CSharp.Symbols.Source.Helpers;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
@@ -226,14 +227,54 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         internal void ComputeReturnType()
         {
-            if (_lazyReturnType is object)
-            {
-                return;
-            }
+            if (_lazyReturnType != null) return;
 
+            bool updateReturnType = true;
             var diagnostics = DiagnosticBag.GetInstance();
             TypeSyntax returnTypeSyntax = Syntax.ReturnType;
             TypeWithAnnotations returnType = _binder.BindType(returnTypeSyntax.SkipRef(), diagnostics);
+
+            // if there is an issue with the return type - try to do the binding from the body - only if this is a method without explicit return type
+            if (returnType.Type?.IsErrorType() == true) 
+            {
+                var hasNoExplicitReturnType = Syntax.ReturnType.Kind() == SyntaxKind.IdentifierName && Syntax.ReturnType.Width == 0;
+                if (hasNoExplicitReturnType)
+                {
+                    // temporarily set the return type before attempting any binding ... it's an error type ... but thats fine ... it will either stay so or will get an infered type from body
+                    Interlocked.Exchange(ref _lazyReturnType, new TypeWithAnnotations.Boxed(returnType));
+                    updateReturnType = true;
+
+                    // bind the body of the function
+                    var tmpDiagnostics = DiagnosticBag.GetInstance();
+                    BoundNode boundBodyNode = null;
+                    if (Syntax.Body != null)
+                    {
+                        boundBodyNode = _binder.BindEmbeddedBlock(Syntax.Body, tmpDiagnostics);
+                    }
+                    else if (Syntax.ExpressionBody != null)
+                    {
+                        boundBodyNode = _binder.BindExpressionBodyAsBlock(Syntax.ExpressionBody, tmpDiagnostics);
+                    }
+                    tmpDiagnostics.Free();
+
+                    if (hasNoExplicitReturnType && boundBodyNode != null)
+                    {
+                        var exitPaths = ArrayBuilder<(BoundNode, TypeWithAnnotations)>.GetInstance();
+                        CodeBlockExitPathsFinder.GetExitPaths(exitPaths, boundBodyNode);
+                        if (exitPaths.Count > 0)
+                        {
+                            // there is some return, so lets use the last return statement
+                            var exitPath = exitPaths.Last();
+                            returnType = exitPath.Item2;
+                        }
+                        else
+                        {
+                            // there is no return, so lets make it "void" per default
+                            returnType = SignatureBinder.BindSpecialType(SyntaxKind.VoidKeyword);
+                        }
+                    }
+                }
+            }
 
             var compilation = DeclaringCompilation;
 
@@ -276,6 +317,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                 if (_lazyReturnType is object)
                 {
                     diagnostics.Free();
+
+                    if(updateReturnType)
+                    {
+                        Interlocked.Exchange(ref _lazyReturnType, new TypeWithAnnotations.Boxed(returnType));
+                    }
                     return;
                 }
 

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             TypeWithAnnotations returnType = signatureBinder.BindType(returnTypeSyntax, diagnostics);
 
             // if it's an error type, try to resolve from the Body instead!
-            if(returnType.Type?.IsErrorType() == true)
+            if(returnType.Type?.IsErrorType() == true && !syntax.HasExplicitReturnType())
             {
                 // try to infer from the body
                 var bodyBinder = TryGetBodyBinder();

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -130,6 +130,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             _lazyIsVararg = (arglistToken.Kind() == SyntaxKind.ArgListKeyword);
             RefKind refKind;
             var returnTypeSyntax = syntax.ReturnType.SkipRef(out refKind);
+
             TypeWithAnnotations returnType = signatureBinder.BindType(returnTypeSyntax, diagnostics);
 
             // if it's an error type, try to resolve from the Body instead!
@@ -149,8 +150,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     CodeBlockExitPathsFinder.GetExitPaths(exitPaths, boundBody);
                     if (exitPaths.Count > 0)
                     {
+                        // there is some return, so lets use the last return statement
                         var exitPath = exitPaths.Last();
                         returnType = exitPath.Item2;
+                    }
+                    else
+                    {
+                        // there is no return, so lets make it "void" per default
+                        returnType = signatureBinder.BindSpecialType(SyntaxKind.VoidKeyword);
                     }
                 }
             }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbolBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private ImmutableArray<MethodSymbol> _lazyExplicitInterfaceImplementations;
         private ImmutableArray<CustomModifier> _lazyRefCustomModifiers;
-        private ImmutableArray<ParameterSymbol> _lazyParameters;
+        protected ImmutableArray<ParameterSymbol> _lazyParameters;
         private TypeWithAnnotations _lazyReturnType;
 
         protected SourceOrdinaryMethodSymbolBase(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -534,6 +534,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                     var exitPath = exitPaths.Last();
                                     type = exitPath.Item2;
                                 }
+                                else
+                                {
+                                    // no exit paths available... so fallback to some "error" by using the explicit type of the property...
+                                    type = prop.GetExplicitReturnTypeWithAnnotations(null, null, diagnostics, out var propRefKind);
+                                }
                                 exitPaths.Free();
                             }
                         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertySymbolBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
         private SymbolCompletionState _state;
         private ImmutableArray<ParameterSymbol> _lazyParameters;
-        private TypeWithAnnotations.Boxed _lazyType;
+        protected TypeWithAnnotations.Boxed _lazyType;
 
         /// <summary>
         /// Set in constructor, might be changed while decoding <see cref="IndexerNameAttribute"/>.

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.FakeTokenWithTrivia.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.FakeTokenWithTrivia.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
+{
+    internal partial class SyntaxToken
+    {
+        internal class FakeTokenWithTrivia : SyntaxTokenWithTrivia
+        {
+            private string _value;
+            private bool _allowTrivia;
+
+            internal FakeTokenWithTrivia(SyntaxKind kind, string value, bool allowTrivia)
+                : base(kind, null, null)
+            {
+                _value = value;
+                _allowTrivia = allowTrivia;
+            }
+
+            internal FakeTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing, string value, bool allowTrivia)
+                : base(kind, leading, trailing)
+            {
+                _value = value;
+                _allowTrivia = allowTrivia;
+            }
+
+            internal FakeTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, string value, bool allowTrivia)
+                : base(kind, leading, trailing, diagnostics, annotations)
+            {
+                _value = value;
+                _allowTrivia = allowTrivia;
+            }
+
+            internal FakeTokenWithTrivia(ObjectReader reader)
+                : base(reader)
+            {
+            }
+
+            static FakeTokenWithTrivia()
+            {
+                ObjectBinder.RegisterTypeReader(typeof(FakeTokenWithTrivia), r => new FakeTokenWithTrivia(r));
+            }
+
+            public override string Text => string.Empty;
+
+            public override object Value => _value;
+
+            public override SyntaxToken TokenWithLeadingTrivia(GreenNode trivia)
+            {
+                return new FakeTokenWithTrivia(this.Kind, _allowTrivia ? trivia : null, this.TrailingField, this.GetDiagnostics(), this.GetAnnotations(), _value, _allowTrivia);
+            }
+
+            public override SyntaxToken TokenWithTrailingTrivia(GreenNode trivia)
+            {
+                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, _allowTrivia ? trivia : null, this.GetDiagnostics(), this.GetAnnotations(), _value, _allowTrivia);
+            }
+
+            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
+            {
+                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, this.TrailingField, diagnostics, this.GetAnnotations(), _value, _allowTrivia);
+            }
+
+            internal override GreenNode SetAnnotations(SyntaxAnnotation[] annotations)
+            {
+                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, this.TrailingField, this.GetDiagnostics(), annotations, _value, _allowTrivia);
+            }
+        }
+    }
+
+    internal static class FakeSyntaxTokenExtensions
+    {
+        internal static bool IsFakeToken(this SyntaxToken token)
+        {
+            return token is SyntaxToken.FakeTokenWithTrivia;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.MissingTokenWithTrivia.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.MissingTokenWithTrivia.cs
@@ -9,67 +9,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 {
     internal partial class SyntaxToken
     {
-        internal class FakeTokenWithTrivia : SyntaxTokenWithTrivia
-        {
-            private string _value;
-            private bool _allowTrivia;
-
-            internal FakeTokenWithTrivia(SyntaxKind kind, string value, bool allowTrivia)
-                : base(kind, null, null)
-            {
-                _value = value;
-                _allowTrivia = allowTrivia;
-            }
-
-            internal FakeTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing, string value, bool allowTrivia)
-                : base(kind, leading, trailing)
-            {
-                _value = value;
-                _allowTrivia = allowTrivia;
-            }
-
-            internal FakeTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing, DiagnosticInfo[] diagnostics, SyntaxAnnotation[] annotations, string value, bool allowTrivia)
-                : base(kind, leading, trailing, diagnostics, annotations)
-            {
-                _value = value;
-                _allowTrivia = allowTrivia;
-            }
-
-            internal FakeTokenWithTrivia(ObjectReader reader)
-                : base(reader)
-            {
-            }
-
-            static FakeTokenWithTrivia()
-            {
-                ObjectBinder.RegisterTypeReader(typeof(FakeTokenWithTrivia), r => new FakeTokenWithTrivia(r));
-            }
-
-            public override string Text => string.Empty;
-
-            public override object Value => _value;
-
-            public override SyntaxToken TokenWithLeadingTrivia(GreenNode trivia)
-            {
-                return new FakeTokenWithTrivia(this.Kind, _allowTrivia ? trivia : null, this.TrailingField, this.GetDiagnostics(), this.GetAnnotations(), _value, _allowTrivia);
-            }
-
-            public override SyntaxToken TokenWithTrailingTrivia(GreenNode trivia)
-            {
-                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, _allowTrivia ? trivia : null, this.GetDiagnostics(), this.GetAnnotations(), _value, _allowTrivia);
-            }
-
-            internal override GreenNode SetDiagnostics(DiagnosticInfo[] diagnostics)
-            {
-                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, this.TrailingField, diagnostics, this.GetAnnotations(), _value, _allowTrivia);
-            }
-
-            internal override GreenNode SetAnnotations(SyntaxAnnotation[] annotations)
-            {
-                return new FakeTokenWithTrivia(this.Kind, this.LeadingField, this.TrailingField, this.GetDiagnostics(), annotations, _value, _allowTrivia);
-            }
-        }
-
         internal class MissingTokenWithTrivia : SyntaxTokenWithTrivia
         {
             internal MissingTokenWithTrivia(SyntaxKind kind, GreenNode leading, GreenNode trailing)

--- a/src/Compilers/CSharp/Portable/Syntax/LocalFunctionStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/LocalFunctionStatementSyntax.cs
@@ -33,5 +33,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
             return Update(attributeLists: default, modifiers, returnType, identifier, typeParameterList, parameterList, constraintClauses, body, expressionBody, semicolonToken);
         }
+
+        public bool HasExplicitReturnType()
+        {
+            var noExplicitReturnType = ReturnType.Kind() == SyntaxKind.IdentifierName && ReturnType.Width == 0;
+            return !noExplicitReturnType;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/MethodDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/MethodDeclarationSyntax.cs
@@ -19,6 +19,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
                 return this.TypeParameterList == null ? 0 : this.TypeParameterList.Parameters.Count;
             }
         }
+
+        public bool HasExplicitReturnType()
+        {
+            var noExplicitReturnType = ReturnType.Kind() == SyntaxKind.IdentifierName && ReturnType.Width == 0;
+            return !noExplicitReturnType;
+        }
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/PropertyDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/PropertyDeclarationSyntax.cs
@@ -28,6 +28,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
             return this.WithSemicolonToken(semicolon);
         }
+
+        public bool HasExplicitReturnType()
+        {
+            var noExplicitReturnType = Type.Kind() == SyntaxKind.IdentifierName && Type.Width == 0;
+            return !noExplicitReturnType;
+        }
     }
 
     // backwards compatibility for API extension

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/FormattingHelpers.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/FormattingHelpers.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.CSharp.Utilities;
 using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.Shared.Extensions;
 
 namespace Microsoft.CodeAnalysis.CSharp.Formatting
 {
@@ -54,7 +55,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
         {
             if (bracePair.openBrace.IsKind(SyntaxKind.None) ||
                 bracePair.openBrace.IsMissing ||
-                bracePair.closeBrace.IsKind(SyntaxKind.None))
+                bracePair.closeBrace.IsKind(SyntaxKind.None) ||
+                bracePair.openBrace.Width() == 0 ||
+                bracePair.closeBrace.Width() == 0)
             {
                 return false;
             }


### PR DESCRIPTION
Adds support for Method / Property declarations without explicit return types and a shorthand Property getter syntax.

Methods can now be defined without explicit return type:
`MyArrowFunction() => "string" //the return type is inferred from the body`
`MyBlockFunction() { return "string"; } //the return type is inferred from the body`

Properties can now be defined without explicit return type:
`MyProperty => "string" //the return type is inferred from the body`

Properties also have a shorthand syntax for implicit getters
`MyProperty { return "string" } //this is an implicit getter with inferred return type from the body`