### PR TITLE
Fixes parsing of generic return types for method return types and loc…

### DIFF
--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -127,6 +127,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return SyntaxToken.CreateFake(kind, value, allowTrivia);
         }
 
+        internal static IdentifierNameSyntax FakeTypeIdentifier(ContextAwareSyntax syntaxFactory = null)
+        {
+            var token = SyntaxFactory.Token(SyntaxKind.IdentifierToken);
+            var type = syntaxFactory?.IdentifierName(token) ?? SyntaxFactory.IdentifierName(token);
+            return type;
+        }
+
         internal static SyntaxToken Token(GreenNode leading, SyntaxKind kind, string text, string valueText, GreenNode trailing)
         {
             Debug.Assert(SyntaxFacts.IsAnyToken(kind));


### PR DESCRIPTION
Fixes parsing of generic return types and local variables - was broken with the addition of method declarations without explicit return types.

Following now works again:
`List<string> GetNames() { return new List<string>(); }`
`List<string> GetNames() => new List<string>()`