### PR TITLE
Bugfix/resolve functions no return type no body

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -113,6 +113,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
             SyntaxToken arglistToken;
 
+            if (Name == "InferEmptyBody")
+            {
+
+            }
+
             // Constraint checking for parameter and return types must be delayed until
             // the method has been added to the containing type member list since
             // evaluating the constraints may depend on accessing this method from
@@ -152,7 +157,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         // there is some return, so lets use the last return statement
                         var exitPath = exitPaths.Last();
-                        returnType = exitPath.Item2;
+                        var exitPathReturnType = exitPath.Item2;
+
+                        // if the return type is null... then there is some issue... we only use the return type if we have a valid one...
+                        if (!ReferenceEquals(exitPathReturnType.Type, null))
+                            returnType = exitPathReturnType;
                     }
                     else
                     {


### PR DESCRIPTION
Fixes two related issues:

1. Functions without explicit return type and a body that could not be resolved / yielded a "null type" would crash
  - fixed by checking for the type and returning an error type instead

2. Functions with "=>" followed by "{}" would crash ... this could sometimes be a useful syntax... so this is now an allowed syntax and is treated as a function with a standard "{}" body block ... the arrow token is simply ignored.

The following now works:
`MyFunctionWithoutExplicitReturnType() => null`
`MyFunctionWithoutExplicitReturnType() => default`
`MyFunctionWithoutExplicitReturnType() { return null; }`

`ArrowBlockCombination() => { return "testing"; }`
`ArrowBlockCombination() => {}`