### PR TITLE
Adds parsing of async / static shorthand arrow and block lambdas

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Patterns.cs
@@ -597,7 +597,7 @@ tryAgain:
         /// </summary>
         private bool IsPossibleSubpatternElement()
         {
-            return this.IsPossibleExpression(allowBinaryExpressions: false, allowAssignmentExpressions: false, allowBraceLambdaExpression: false) ||
+            return this.IsPossibleExpression(allowBinaryExpressions: false, allowAssignmentExpressions: false, allowBraceLambdaExpression: false, allowArrowLambdaExpression: false) ||
                 this.CurrentToken.Kind switch
                 {
                     SyntaxKind.OpenBraceToken => true,


### PR DESCRIPTION
Enables syntax for async shorthand lambdas.

The following is now possible:

`AsyncCallbackMethod(async => await SomeAsyncOperation())`
`AsyncCallbackMethod(async { await SomeAsyncOperation(); })`