### PR TITLE
Adds type resolving for functions without return type declared in interface

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -169,6 +169,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         returnType = signatureBinder.BindSpecialType(SyntaxKind.VoidKeyword);
                     }
                 }
+                else
+                {
+                    // could be that there is no body defined... in that case we can pretty much assume it's a "void" type
+                    var (arrowBody, blockBody) = Bodies;
+                    if (arrowBody == null && blockBody == null)
+                    {
+                        returnType = signatureBinder.BindSpecialType(SyntaxKind.VoidKeyword);
+                    }
+                }
             }
 
             // span-like types are returnable in general


### PR DESCRIPTION
Adds type inference for functions without a return type that are declared in an interface - same as with member functions in classes.

If no return type is specified - there i really nothing to infer from the body - so per default they get "void" as return type.

Enables the following syntax:
`interface ITest { MyMethod(); }`