### PR TITLE
Adds inference helper class with best-type inference

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/Helpers/CodeBlockReturnTypeResolver.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/Helpers/CodeBlockReturnTypeResolver.cs
@@ -1,11 +1,17 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Microsoft.CodeAnalysis.PooledObjects;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols.Source.Helpers
 {
     internal class CodeBlockReturnTypeResolver
     {
-        public static (TypeWithAnnotations? resolvedType, bool isVoidType) TryResolveReturnType(BoundNode? boundNode)
+        public static (TypeWithAnnotations? resolvedType, bool isVoidType) TryResolveReturnType(BoundNode? boundNode, ConversionsBase conversions)
+        {
+            return TryResolveReturnType(boundNode, conversions, out var _);
+        }
+
+        public static (TypeWithAnnotations? resolvedType, bool isVoidType) TryResolveReturnType(BoundNode? boundNode, ConversionsBase conversions, out HashSet<DiagnosticInfo> useSiteDiagnostics)
         {
             bool isInferrableReturnStatement(BoundNode node)
             {
@@ -17,31 +23,83 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.Source.Helpers
                 return false;
             }
 
+            useSiteDiagnostics = null;
             var exitPaths = ArrayBuilder<(BoundNode, TypeWithAnnotations)>.GetInstance();
             try
             {
                 CodeBlockExitPathsFinder.GetExitPaths(exitPaths, boundNode);
 
                 // get the exit paths that can be infered from
-                var inferrableExitPaths = exitPaths.Where(p => isInferrableReturnStatement(p.Item1));
+                var inferrableExitPaths = exitPaths.Where(p => isInferrableReturnStatement(p.Item1)).ToList();
 
-                // use the last exit path and try to infer from it
-                var lastExitPath = inferrableExitPaths.LastOrDefault();
-                if (lastExitPath.Item1 != null)
+                TypeWithAnnotations? resolvedType = null;
+
+                if (inferrableExitPaths.Count > 1)
                 {
-                    // there is some return, so lets use the last return statement
-                    var exitPathReturnType = lastExitPath.Item2;
+                    var types = ArrayBuilder<TypeSymbol>.GetInstance();
+                    // try finding the best common type
+                    try
+                    {
+                        TypeWithAnnotations? lastType = null;
+                        foreach (var p in inferrableExitPaths)
+                        {
+                            if (p.Item1 == null) continue;
 
-                    // if the return type is null... then there is some issue... we only use the return type if we have a valid one...
-                    if (!ReferenceEquals(exitPathReturnType.Type, null))
-                        return (exitPathReturnType, false);
+                            var type = p.Item2;
+                            if (ReferenceEquals(type.Type, null)) continue;
 
-                    return (null, false);
+                            lastType = type;
+                            types.Add(type.Type);
+                        }
+
+                        // no valid type to resolve from?
+                        if (types.Count == 0) return (null, false);
+
+                        // if we have more than one type to resolve from...
+                        if (types.Count > 1)
+                        {
+                            useSiteDiagnostics = new HashSet<DiagnosticInfo>();
+                            var bestType = BestTypeInferrer.GetBestType(types, conversions, ref useSiteDiagnostics);
+
+                            // if no best type ... then we don't know ...
+                            if ((object)bestType == null) return (null, false);
+
+                            // we have a resolved type
+                            resolvedType = TypeWithAnnotations.Create(false, bestType);
+                            return (resolvedType, false);
+                        }
+
+                        // there is only a single type to resolve from
+                        if (!ReferenceEquals(lastType?.Type, null))
+                            return (lastType, false);
+
+                        // no valid type... so must be void
+                        return (null, true);
+                    }
+                    finally
+                    {
+                        types.Free();
+                    }
                 }
                 else
                 {
-                    // there is no return, so lets make it "void" per default
-                    return (null, true);
+                    var lastExitPath = inferrableExitPaths.LastOrDefault();
+                    if (lastExitPath.Item1 != null)
+                    {
+                        // there is some return, so lets use the last return statement
+                        var exitPathReturnType = lastExitPath.Item2;
+
+                        // if the return type is null... then there is some issue... we only use the return type if we have a valid one...
+                        if (!ReferenceEquals(exitPathReturnType.Type, null))
+                            return (exitPathReturnType, false);
+
+                        return (null, false);
+                    }
+                    else
+                    {
+                        // there is no return, so lets make it "void" per default
+                        return (null, true);
+                    }
                 }
             }
             finally

--- a/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/LocalFunctionSymbol.cs
@@ -252,7 +252,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 if (boundBodyNode != null)
                 {
-                    var (resolvedType, isVoidType) = CodeBlockReturnTypeResolver.TryResolveReturnType(boundBodyNode);
+                    var (resolvedType, isVoidType) = CodeBlockReturnTypeResolver.TryResolveReturnType(boundBodyNode, _binder.Conversions);
                     if (isVoidType) returnType = SignatureBinder.BindSpecialType(SyntaxKind.VoidKeyword);
                     else if (resolvedType != null) returnType = resolvedType.Value;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -146,7 +146,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     // evaluate method body
                     var bodyDiagnostics = new DiagnosticBag();
                     var boundBody = bodyBinder.BindMethodBody(syntax, bodyDiagnostics);
-                    var (resolvedType, isVoidType) = CodeBlockReturnTypeResolver.TryResolveReturnType(boundBody);
+                    var (resolvedType, isVoidType) = CodeBlockReturnTypeResolver.TryResolveReturnType(boundBody, bodyBinder.Conversions, out var useSiteDiagnostics);
                     if (isVoidType) returnType = signatureBinder.BindSpecialType(SyntaxKind.VoidKeyword);
                     else if (resolvedType != null) returnType = resolvedType.Value;
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -526,7 +526,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                             if (boundBody != null)
                             {
-                                var (resolvedType, isVoidType) = CodeBlockReturnTypeResolver.TryResolveReturnType(boundBody);
+                                var (resolvedType, isVoidType) = CodeBlockReturnTypeResolver.TryResolveReturnType(boundBody, bodyBinder.Conversions);
                                 if (isVoidType) type = prop.GetExplicitReturnTypeWithAnnotations(null, null, diagnostics, out var propRefKind);
                                 else if (resolvedType != null) type = resolvedType.Value;
                             }


### PR DESCRIPTION
Adds better inference logic when inferring the return type for methods without explicit return type declared.

The logic evaluates the type of all possible return paths from the block and resolves the "best common type" among those.

Enables the following syntax:
`
MyFunctionWithMultipleReturns() {
  if(thisIsTrue) {
    return new List<int>() { 1, 2, 3 };
  }
  if(otherIsTrue) {
    return new (IEnumerable)List<int>() { 4, 5, 6 };
  }
  return new Collection<int>();
}
`

The "best common type" from the above is IEnumerable which is shared between the types of those return expressions.