### PR TITLE
Feature/trailing block lambda invocation arg

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Expressions.cs
@@ -2629,7 +2629,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         {
             if (argumentListOpt != null)
             {
-                BindArgumentsAndNames(argumentListOpt.Arguments, diagnostics, result, allowArglist, isDelegateCreation: isDelegateCreation);
+                BindArgumentsAndNames(argumentListOpt.Arguments, diagnostics, result, allowArglist, isDelegateCreation: isDelegateCreation, argumentListOpt.TrailingLambdaBlock);
             }
         }
 
@@ -2646,7 +2646,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             DiagnosticBag diagnostics,
             AnalyzedArguments result,
             bool allowArglist,
-            bool isDelegateCreation = false)
+            bool isDelegateCreation = false,
+            ParenthesizedLambdaExpressionSyntax? trailingBlockArg = null)
         {
             // Only report the first "duplicate name" or "named before positional" error,
             // so as to avoid "cascading" errors.
@@ -2660,6 +2661,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 BindArgumentAndName(result, diagnostics, ref hadError, ref hadLangVersionError,
                     argumentSyntax, allowArglist, isDelegateCreation: isDelegateCreation);
+            }
+
+            if (trailingBlockArg != null)
+            {
+                var trailingArgSyntax = SyntaxFactory.Argument(trailingBlockArg);
+                BindArgumentAndName(result, diagnostics, ref hadError, ref hadLangVersionError,
+                    trailingArgSyntax, allowArglist, isDelegateCreation: isDelegateCreation);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/CSharpCompilation.cs
@@ -933,8 +933,12 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         internal override int GetSyntaxTreeOrdinal(SyntaxTree tree)
         {
-            Debug.Assert(this.ContainsSyntaxTree(tree));
-            return _syntaxAndDeclarations.GetLazyState().OrdinalMap[tree];
+            //Debug.Assert(this.ContainsSyntaxTree(tree) || this.ContainsSyntaxTree(tree?.GetRoot()?.SyntaxTree));
+            var lazyState = _syntaxAndDeclarations.GetLazyState();
+            if (lazyState.OrdinalMap.TryGetValue(tree, out var ordinal)) return ordinal;
+            var root = tree.GetRoot();
+            if (lazyState.OrdinalMap.TryGetValue(root.SyntaxTree, out var rootOrdinal)) return rootOrdinal;
+            return 0;
         }
 
         #endregion

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -274,10 +274,17 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
                 else if (current.IsAnonymousFunction())
                 {
+                    var binderRequired = true;
+                    if(current.Parent is ArgumentListSyntax argListSyntax && argListSyntax.TrailingLambdaBlock == current)
+                    {
+                        binderRequired = false;
+                    }
+
                     if (LookupPosition.IsInAnonymousFunctionOrQuery(position, current))
                     {
                         binder = rootBinder.GetBinder(current.AnonymousFunctionBody());
-                        Debug.Assert(binder != null);
+
+                        if(binderRequired) Debug.Assert(binder != null);
                     }
                 }
                 else if (kind == SyntaxKind.TypeOfExpression &&

--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -166,7 +166,11 @@ constructor_initializer
   ;
 
 argument_list
-  : '(' (argument (',' argument)*)? ')'
+  : '(' (argument (',' argument)*)? ')' parenthesized_lambda_expression?
+  ;
+
+parenthesized_lambda_expression
+  : modifier* parameter_list '=>' (block | expression)
   ;
 
 block
@@ -720,10 +724,6 @@ anonymous_method_expression
 lambda_expression
   : parenthesized_lambda_expression
   | simple_lambda_expression
-  ;
-
-parenthesized_lambda_expression
-  : modifier* parameter_list '=>' (block | expression)
   ;
 
 simple_lambda_expression

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -4861,11 +4861,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         internal readonly SyntaxToken openParenToken;
         internal readonly GreenNode? arguments;
         internal readonly SyntaxToken closeParenToken;
+        internal readonly ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock;
 
-        internal ArgumentListSyntax(SyntaxKind kind, SyntaxToken openParenToken, GreenNode? arguments, SyntaxToken closeParenToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal ArgumentListSyntax(SyntaxKind kind, SyntaxToken openParenToken, GreenNode? arguments, SyntaxToken closeParenToken, ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
-            this.SlotCount = 3;
+            this.SlotCount = 4;
             this.AdjustFlagsAndWidth(openParenToken);
             this.openParenToken = openParenToken;
             if (arguments != null)
@@ -4875,13 +4876,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(closeParenToken);
             this.closeParenToken = closeParenToken;
+            if (trailingLambdaBlock != null)
+            {
+                this.AdjustFlagsAndWidth(trailingLambdaBlock);
+                this.trailingLambdaBlock = trailingLambdaBlock;
+            }
         }
 
-        internal ArgumentListSyntax(SyntaxKind kind, SyntaxToken openParenToken, GreenNode? arguments, SyntaxToken closeParenToken, SyntaxFactoryContext context)
+        internal ArgumentListSyntax(SyntaxKind kind, SyntaxToken openParenToken, GreenNode? arguments, SyntaxToken closeParenToken, ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
-            this.SlotCount = 3;
+            this.SlotCount = 4;
             this.AdjustFlagsAndWidth(openParenToken);
             this.openParenToken = openParenToken;
             if (arguments != null)
@@ -4891,12 +4897,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(closeParenToken);
             this.closeParenToken = closeParenToken;
+            if (trailingLambdaBlock != null)
+            {
+                this.AdjustFlagsAndWidth(trailingLambdaBlock);
+                this.trailingLambdaBlock = trailingLambdaBlock;
+            }
         }
 
-        internal ArgumentListSyntax(SyntaxKind kind, SyntaxToken openParenToken, GreenNode? arguments, SyntaxToken closeParenToken)
+        internal ArgumentListSyntax(SyntaxKind kind, SyntaxToken openParenToken, GreenNode? arguments, SyntaxToken closeParenToken, ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock)
           : base(kind)
         {
-            this.SlotCount = 3;
+            this.SlotCount = 4;
             this.AdjustFlagsAndWidth(openParenToken);
             this.openParenToken = openParenToken;
             if (arguments != null)
@@ -4906,6 +4917,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(closeParenToken);
             this.closeParenToken = closeParenToken;
+            if (trailingLambdaBlock != null)
+            {
+                this.AdjustFlagsAndWidth(trailingLambdaBlock);
+                this.trailingLambdaBlock = trailingLambdaBlock;
+            }
         }
 
         /// <summary>SyntaxToken representing open parenthesis.</summary>
@@ -4914,6 +4930,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> Arguments => new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax>(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<CSharpSyntaxNode>(this.arguments));
         /// <summary>SyntaxToken representing close parenthesis.</summary>
         public SyntaxToken CloseParenToken => this.closeParenToken;
+        /// <summary>Block syntax representing an additional argument outside the parenthesis.</summary>
+        public ParenthesizedLambdaExpressionSyntax? TrailingLambdaBlock => this.trailingLambdaBlock;
 
         internal override GreenNode? GetSlot(int index)
             => index switch
@@ -4921,6 +4939,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 0 => this.openParenToken,
                 1 => this.arguments,
                 2 => this.closeParenToken,
+                3 => this.trailingLambdaBlock,
                 _ => null,
             };
 
@@ -4929,11 +4948,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitArgumentList(this);
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitArgumentList(this);
 
-        public ArgumentListSyntax Update(SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken)
+        public ArgumentListSyntax Update(SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken, ParenthesizedLambdaExpressionSyntax trailingLambdaBlock)
         {
-            if (openParenToken != this.OpenParenToken || arguments != this.Arguments || closeParenToken != this.CloseParenToken)
+            if (openParenToken != this.OpenParenToken || arguments != this.Arguments || closeParenToken != this.CloseParenToken || trailingLambdaBlock != this.TrailingLambdaBlock)
             {
-                var newNode = SyntaxFactory.ArgumentList(openParenToken, arguments, closeParenToken);
+                var newNode = SyntaxFactory.ArgumentList(openParenToken, arguments, closeParenToken, trailingLambdaBlock);
                 var diags = GetDiagnostics();
                 if (diags?.Length > 0)
                     newNode = newNode.WithDiagnosticsGreen(diags);
@@ -4947,15 +4966,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-            => new ArgumentListSyntax(this.Kind, this.openParenToken, this.arguments, this.closeParenToken, diagnostics, GetAnnotations());
+            => new ArgumentListSyntax(this.Kind, this.openParenToken, this.arguments, this.closeParenToken, this.trailingLambdaBlock, diagnostics, GetAnnotations());
 
         internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-            => new ArgumentListSyntax(this.Kind, this.openParenToken, this.arguments, this.closeParenToken, GetDiagnostics(), annotations);
+            => new ArgumentListSyntax(this.Kind, this.openParenToken, this.arguments, this.closeParenToken, this.trailingLambdaBlock, GetDiagnostics(), annotations);
 
         internal ArgumentListSyntax(ObjectReader reader)
           : base(reader)
         {
-            this.SlotCount = 3;
+            this.SlotCount = 4;
             var openParenToken = (SyntaxToken)reader.ReadValue();
             AdjustFlagsAndWidth(openParenToken);
             this.openParenToken = openParenToken;
@@ -4968,6 +4987,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             var closeParenToken = (SyntaxToken)reader.ReadValue();
             AdjustFlagsAndWidth(closeParenToken);
             this.closeParenToken = closeParenToken;
+            var trailingLambdaBlock = (ParenthesizedLambdaExpressionSyntax?)reader.ReadValue();
+            if (trailingLambdaBlock != null)
+            {
+                AdjustFlagsAndWidth(trailingLambdaBlock);
+                this.trailingLambdaBlock = trailingLambdaBlock;
+            }
         }
 
         internal override void WriteTo(ObjectWriter writer)
@@ -4976,6 +5001,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             writer.WriteValue(this.openParenToken);
             writer.WriteValue(this.arguments);
             writer.WriteValue(this.closeParenToken);
+            writer.WriteValue(this.trailingLambdaBlock);
         }
 
         static ArgumentListSyntax()
@@ -32953,7 +32979,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             => node.Update((ExpressionSyntax)Visit(node.Expression), (BracketedArgumentListSyntax)Visit(node.ArgumentList));
 
         public override CSharpSyntaxNode VisitArgumentList(ArgumentListSyntax node)
-            => node.Update((SyntaxToken)Visit(node.OpenParenToken), VisitList(node.Arguments), (SyntaxToken)Visit(node.CloseParenToken));
+            => node.Update((SyntaxToken)Visit(node.OpenParenToken), VisitList(node.Arguments), (SyntaxToken)Visit(node.CloseParenToken), (ParenthesizedLambdaExpressionSyntax)Visit(node.TrailingLambdaBlock));
 
         public override CSharpSyntaxNode VisitBracketedArgumentList(BracketedArgumentListSyntax node)
             => node.Update((SyntaxToken)Visit(node.OpenBracketToken), VisitList(node.Arguments), (SyntaxToken)Visit(node.CloseBracketToken));
@@ -34526,7 +34552,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public ArgumentListSyntax ArgumentList(SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken)
+        public ArgumentListSyntax ArgumentList(SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken, ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock)
         {
 #if DEBUG
             if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
@@ -34535,17 +34561,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
 #endif
 
-            int hash;
-            var cached = CSharpSyntaxNodeCache.TryGetNode((int)SyntaxKind.ArgumentList, openParenToken, arguments.Node, closeParenToken, this.context, out hash);
-            if (cached != null) return (ArgumentListSyntax)cached;
-
-            var result = new ArgumentListSyntax(SyntaxKind.ArgumentList, openParenToken, arguments.Node, closeParenToken, this.context);
-            if (hash >= 0)
-            {
-                SyntaxNodeCache.AddNode(result, hash);
-            }
-
-            return result;
+            return new ArgumentListSyntax(SyntaxKind.ArgumentList, openParenToken, arguments.Node, closeParenToken, trailingLambdaBlock, this.context);
         }
 
         public BracketedArgumentListSyntax BracketedArgumentList(SyntaxToken openBracketToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeBracketToken)
@@ -39289,7 +39305,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public static ArgumentListSyntax ArgumentList(SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken)
+        public static ArgumentListSyntax ArgumentList(SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken, ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock)
         {
 #if DEBUG
             if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
@@ -39298,17 +39314,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
 #endif
 
-            int hash;
-            var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.ArgumentList, openParenToken, arguments.Node, closeParenToken, out hash);
-            if (cached != null) return (ArgumentListSyntax)cached;
-
-            var result = new ArgumentListSyntax(SyntaxKind.ArgumentList, openParenToken, arguments.Node, closeParenToken);
-            if (hash >= 0)
-            {
-                SyntaxNodeCache.AddNode(result, hash);
-            }
-
-            return result;
+            return new ArgumentListSyntax(SyntaxKind.ArgumentList, openParenToken, arguments.Node, closeParenToken, trailingLambdaBlock);
         }
 
         public static BracketedArgumentListSyntax BracketedArgumentList(SyntaxToken openBracketToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeBracketToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -1727,7 +1727,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => node.Update((ExpressionSyntax?)Visit(node.Expression) ?? throw new ArgumentNullException("expression"), (BracketedArgumentListSyntax?)Visit(node.ArgumentList) ?? throw new ArgumentNullException("argumentList"));
 
         public override SyntaxNode? VisitArgumentList(ArgumentListSyntax node)
-            => node.Update(VisitToken(node.OpenParenToken), VisitList(node.Arguments), VisitToken(node.CloseParenToken));
+            => node.Update(VisitToken(node.OpenParenToken), VisitList(node.Arguments), VisitToken(node.CloseParenToken), (ParenthesizedLambdaExpressionSyntax?)Visit(node.TrailingLambdaBlock));
 
         public override SyntaxNode? VisitBracketedArgumentList(BracketedArgumentListSyntax node)
             => node.Update(VisitToken(node.OpenBracketToken), VisitList(node.Arguments), VisitToken(node.CloseBracketToken));
@@ -3100,16 +3100,20 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SyntaxFactory.ElementAccessExpression(expression, SyntaxFactory.BracketedArgumentList());
 
         /// <summary>Creates a new ArgumentListSyntax instance.</summary>
-        public static ArgumentListSyntax ArgumentList(SyntaxToken openParenToken, SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken)
+        public static ArgumentListSyntax ArgumentList(SyntaxToken openParenToken, SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeParenToken, ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock)
         {
             if (openParenToken.Kind() != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
             if (closeParenToken.Kind() != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
-            return (ArgumentListSyntax)Syntax.InternalSyntax.SyntaxFactory.ArgumentList((Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, arguments.Node.ToGreenSeparatedList<Syntax.InternalSyntax.ArgumentSyntax>(), (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!).CreateRed();
+            return (ArgumentListSyntax)Syntax.InternalSyntax.SyntaxFactory.ArgumentList((Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, arguments.Node.ToGreenSeparatedList<Syntax.InternalSyntax.ArgumentSyntax>(), (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!, trailingLambdaBlock == null ? null : (Syntax.InternalSyntax.ParenthesizedLambdaExpressionSyntax)trailingLambdaBlock.Green).CreateRed();
         }
 
         /// <summary>Creates a new ArgumentListSyntax instance.</summary>
+        public static ArgumentListSyntax ArgumentList(SeparatedSyntaxList<ArgumentSyntax> arguments, ParenthesizedLambdaExpressionSyntax? trailingLambdaBlock)
+            => SyntaxFactory.ArgumentList(SyntaxFactory.Token(SyntaxKind.OpenParenToken), arguments, SyntaxFactory.Token(SyntaxKind.CloseParenToken), trailingLambdaBlock);
+
+        /// <summary>Creates a new ArgumentListSyntax instance.</summary>
         public static ArgumentListSyntax ArgumentList(SeparatedSyntaxList<ArgumentSyntax> arguments = default)
-            => SyntaxFactory.ArgumentList(SyntaxFactory.Token(SyntaxKind.OpenParenToken), arguments, SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => SyntaxFactory.ArgumentList(SyntaxFactory.Token(SyntaxKind.OpenParenToken), arguments, SyntaxFactory.Token(SyntaxKind.CloseParenToken), default);
 
         /// <summary>Creates a new BracketedArgumentListSyntax instance.</summary>
         public static BracketedArgumentListSyntax BracketedArgumentList(SyntaxToken openBracketToken, SeparatedSyntaxList<ArgumentSyntax> arguments, SyntaxToken closeBracketToken)

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -1130,6 +1130,11 @@
         <summary>SyntaxToken representing close parenthesis.</summary>
       </PropertyComment>
     </Field>
+    <Field Name="TrailingLambdaBlock" Type="ParenthesizedLambdaExpressionSyntax" Optional="true">
+      <PropertyComment>
+        <summary>Block syntax representing an additional argument outside the parenthesis.</summary>
+      </PropertyComment>
+    </Field>
     <TypeComment>
       <summary>Class which represents the syntax node for the list of arguments.</summary>
     </TypeComment>

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -134,7 +134,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.ElementAccessExpression(GenerateIdentifierName(), GenerateBracketedArgumentList());
 
         private static Syntax.InternalSyntax.ArgumentListSyntax GenerateArgumentList()
-            => InternalSyntaxFactory.ArgumentList(InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ArgumentSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => InternalSyntaxFactory.ArgumentList(InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ArgumentSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken), null);
 
         private static Syntax.InternalSyntax.BracketedArgumentListSyntax GenerateBracketedArgumentList()
             => InternalSyntaxFactory.BracketedArgumentList(InternalSyntaxFactory.Token(SyntaxKind.OpenBracketToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ArgumentSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseBracketToken));
@@ -1177,6 +1177,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
             Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
+            Assert.Null(node.TrailingLambdaBlock);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -9597,7 +9598,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.ElementAccessExpression(GenerateIdentifierName(), GenerateBracketedArgumentList());
 
         private static ArgumentListSyntax GenerateArgumentList()
-            => SyntaxFactory.ArgumentList(SyntaxFactory.Token(SyntaxKind.OpenParenToken), new SeparatedSyntaxList<ArgumentSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => SyntaxFactory.ArgumentList(SyntaxFactory.Token(SyntaxKind.OpenParenToken), new SeparatedSyntaxList<ArgumentSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseParenToken), default(ParenthesizedLambdaExpressionSyntax));
 
         private static BracketedArgumentListSyntax GenerateBracketedArgumentList()
             => SyntaxFactory.BracketedArgumentList(SyntaxFactory.Token(SyntaxKind.OpenBracketToken), new SeparatedSyntaxList<ArgumentSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseBracketToken));
@@ -10640,7 +10641,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
             Assert.Equal(default, node.Arguments);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
-            var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken);
+            Assert.Null(node.TrailingLambdaBlock);
+            var newNode = node.WithOpenParenToken(node.OpenParenToken).WithArguments(node.Arguments).WithCloseParenToken(node.CloseParenToken).WithTrailingLambdaBlock(node.TrailingLambdaBlock);
             Assert.Equal(node, newNode);
         }
 

--- a/src/Features/CSharp/Portable/ConvertAnonymousTypeToClass/CSharpConvertAnonymousTypeToClassCodeRefactoringProvider.cs
+++ b/src/Features/CSharp/Portable/ConvertAnonymousTypeToClass/CSharpConvertAnonymousTypeToClassCodeRefactoringProvider.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp.ConvertAnonymousTypeToClass
             => SyntaxFactory.ArgumentList(
                 SyntaxFactory.Token(SyntaxKind.OpenParenToken).WithTriviaFrom(anonymousObject.OpenBraceToken),
                 CreateArguments(anonymousObject.Initializers),
-                SyntaxFactory.Token(SyntaxKind.CloseParenToken).WithTriviaFrom(anonymousObject.CloseBraceToken));
+                SyntaxFactory.Token(SyntaxKind.CloseParenToken).WithTriviaFrom(anonymousObject.CloseBraceToken), null);
 
         private SeparatedSyntaxList<ArgumentSyntax> CreateArguments(SeparatedSyntaxList<AnonymousObjectMemberDeclaratorSyntax> initializers)
             => SyntaxFactory.SeparatedList<ArgumentSyntax>(CreateArguments(OmitTrailingComma(initializers.GetWithSeparators())));

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3151,7 +3151,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         internal override SyntaxNode ObjectCreationExpression(SyntaxNode type, SyntaxToken openParen, SeparatedSyntaxList<SyntaxNode> arguments, SyntaxToken closeParen)
             => SyntaxFactory.ObjectCreationExpression(
                 (TypeSyntax)type,
-                SyntaxFactory.ArgumentList(openParen, arguments, closeParen),
+                SyntaxFactory.ArgumentList(openParen, arguments, closeParen, null),
                 initializer: null);
 
         private static ArgumentListSyntax CreateArgumentList(IEnumerable<SyntaxNode> arguments)


### PR DESCRIPTION
This adds "trailing lambda args" - basically code blocks that follow a method call - the block is then treated as an additional argument to the method call.

Enables the following syntax:
`MyFunction(string arg1 = null, Action callback = null) {...} // this is the function definition`

`MyFunction("arg 1 value") {/* this is the "callback" argument */} // this is the function call with trailing {} block that is treated as an additional argument`

`MyFunction() {/* this is the "callback" argument */} // this is NOT allowed... use call without parenthesis when no parameters`

`MyFunction {/* this is the "callback" argument */} // this is valid, same as above - but explicit for when no args are passed...`