### PR TITLE
Adds special case type inference for overridden properties

### DIFF
--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourcePropertyAccessorSymbol.cs
@@ -500,6 +500,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
 
                 var prop = _property as SourcePropertySymbol;
                 var propDeclSyntax = prop?.CSharpSyntaxNode as PropertyDeclarationSyntax;
+                var isOverride = prop?.IsOverride == true;
 
                 if (propDeclSyntax != null)
                 {
@@ -507,6 +508,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                     {
                         // use the explicit return type from property
                         type = prop.GetExplicitReturnTypeWithAnnotations(null, null, diagnostics, out var propRefKind);
+                    }
+                    else if (isOverride)
+                    {
+                        // we can only resolve to the same type as the overridden type
+                        type = prop.GetOverriddenReturnTypeWithAnnotations();
                     }
                     else
                     {


### PR DESCRIPTION
Override property syntax would cause an infinite loop in the inference logic ... this handles override properties explicitly and infers to the type of the overridden property.

Fixes the following broken syntax:

`public override MyValue => // this breaks ... causing Visual Studio to "hang" ...`