### PR TITLE
Updates parsing of using statements

### DIFF
--- a/src/Compilers/CSharp/Portable/Declarations/DeclarationKind.cs
+++ b/src/Compilers/CSharp/Portable/Declarations/DeclarationKind.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.IO;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;


### PR DESCRIPTION
Updates syntax of using statements - removing the need for the parenthesis and adding the postfix type declaration.

Enables the following syntax:

`using d := new MyDisposable() // no need for 'var' and no parenthesis`

`using d := new MyDisposable() { Console.WriteLine("ooops, ambiguous?") } // no need for parenthesis causing ambiguity with object initializer ... but this is simply how it is...`

`using d := CreateMyDisposable() { Console.WriteLine("this is the disposable logic") }`