### PR TITLE
Feature/assignment intellisense formatting

### DIFF
--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/TokenBasedFormattingRule.cs
@@ -5,6 +5,7 @@
 #nullable enable
 
 using System;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Extensions;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -399,7 +400,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
                                                SyntaxKind.NameColon,
                                                SyntaxKind.SwitchExpressionArm))
                 {
-                    return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+                    // when typing 'myValue :' ... the following is often a "=", which is part of an assignment declaration...
+                    // only apply this if we have a "successfully parsed" label statement
+                    if (!currentToken.Parent.IsKind(SyntaxKind.LabeledStatement) || !currentToken.Parent.GetDiagnostics().Any(d => d.Severity == DiagnosticSeverity.Error))
+                    {
+                        return CreateAdjustSpacesOperation(0, AdjustSpacesOption.ForceSpacesIfOnSingleLine);
+                    }
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -2245,6 +2245,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             }
 
             // q = |
+            // q := |
             // q -= |
             // q *= |
             // q += |
@@ -2257,6 +2258,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // q >>= |
             // q ??= |
             if (token.IsKind(SyntaxKind.EqualsToken) ||
+                token.IsKind(SyntaxKind.ColonEqualsToken) ||
                 token.IsKind(SyntaxKind.MinusEqualsToken) ||
                 token.IsKind(SyntaxKind.AsteriskEqualsToken) ||
                 token.IsKind(SyntaxKind.PlusEqualsToken) ||
@@ -2268,7 +2270,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
                 token.IsKind(SyntaxKind.PercentEqualsToken) ||
                 token.IsKind(SyntaxKind.LessThanLessThanEqualsToken) ||
                 token.IsKind(SyntaxKind.GreaterThanGreaterThanEqualsToken) ||
-                token.IsKind(SyntaxKind.QuestionQuestionEqualsToken))
+                token.IsKind(SyntaxKind.QuestionQuestionEqualsToken)
+                )
             {
                 return true;
             }


### PR DESCRIPTION
Updates the formatting when typing "value :=" assignments - ignoring the spacing rules for ":" and also updates the intellisense / autocompletion following the ":=".

* Space is preserved between the variable target and the ":="

* Insellisense / autocompletion works for the tokens following ":="