### PR TITLE
Fix parsing of parameter list to exclude broken syntax due to Tuples

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -313,6 +313,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
+        protected bool IsTokenAfterWhitespace(SyntaxToken token, SyntaxToken prevToken)
+        {
+            if (token.LeadingTrivia.Any((int)SyntaxKind.WhitespaceTrivia)) return true;
+            if (prevToken != null && prevToken.TrailingTrivia.Any((int)SyntaxKind.WhitespaceTrivia)) return true;
+            return false;
+        }
+
         protected bool IsCurrentLineIndented
         {
             get


### PR DESCRIPTION
Fixes issue with parsing parameters due to "tuple parsing" - now invocation expressions were treated as local declarations with the "(...)" as tuple types ... this fixes the issue by making the speculative parsing of parenthesized parameter list more strict.