### PR TITLE
Feature/fn lambda type

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -340,6 +340,7 @@ namespace_declaration
 type
   : array_type
   | function_pointer_type
+  | lambda_function_type
   | name
   | nullable_type
   | omitted_type_argument
@@ -359,6 +360,10 @@ array_rank_specifier
 
 function_pointer_type
   : 'delegate' '*' syntax_token? '<' parameter (',' parameter)* '>'
+  ;
+
+lambda_function_type
+  : fn_keyword '(' (parameter (',' parameter)*)? ')' type?
   ;
 
 nullable_type
@@ -1276,6 +1281,10 @@ character_literal_token
 expression_or_pattern
   : expression
   | pattern
+  ;
+
+fn_keyword
+  : /* see lexical specification */
   ;
 
 identifier_token

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -1049,6 +1049,173 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
     }
 
+    internal sealed partial class LambdaFunctionTypeSyntax : TypeSyntax
+    {
+        internal readonly SyntaxToken fnKeyword;
+        internal readonly SyntaxToken openParenToken;
+        internal readonly GreenNode? parameters;
+        internal readonly SyntaxToken closeParenToken;
+        internal readonly TypeSyntax? returnType;
+
+        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+          : base(kind, diagnostics, annotations)
+        {
+            this.SlotCount = 5;
+            this.AdjustFlagsAndWidth(fnKeyword);
+            this.fnKeyword = fnKeyword;
+            this.AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            if (parameters != null)
+            {
+                this.AdjustFlagsAndWidth(parameters);
+                this.parameters = parameters;
+            }
+            this.AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+            if (returnType != null)
+            {
+                this.AdjustFlagsAndWidth(returnType);
+                this.returnType = returnType;
+            }
+        }
+
+        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType, SyntaxFactoryContext context)
+          : base(kind)
+        {
+            this.SetFactoryContext(context);
+            this.SlotCount = 5;
+            this.AdjustFlagsAndWidth(fnKeyword);
+            this.fnKeyword = fnKeyword;
+            this.AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            if (parameters != null)
+            {
+                this.AdjustFlagsAndWidth(parameters);
+                this.parameters = parameters;
+            }
+            this.AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+            if (returnType != null)
+            {
+                this.AdjustFlagsAndWidth(returnType);
+                this.returnType = returnType;
+            }
+        }
+
+        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+          : base(kind)
+        {
+            this.SlotCount = 5;
+            this.AdjustFlagsAndWidth(fnKeyword);
+            this.fnKeyword = fnKeyword;
+            this.AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            if (parameters != null)
+            {
+                this.AdjustFlagsAndWidth(parameters);
+                this.parameters = parameters;
+            }
+            this.AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+            if (returnType != null)
+            {
+                this.AdjustFlagsAndWidth(returnType);
+                this.returnType = returnType;
+            }
+        }
+
+        /// <summary>SyntaxToken representing the fn keyword.</summary>
+        public SyntaxToken FnKeyword => this.fnKeyword;
+        /// <summary>Gets the open paren token.</summary>
+        public SyntaxToken OpenParenToken => this.openParenToken;
+        public Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> Parameters => new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax>(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<CSharpSyntaxNode>(this.parameters));
+        /// <summary>Gets the close paren token.</summary>
+        public SyntaxToken CloseParenToken => this.closeParenToken;
+        /// <summary>Gets the return type.</summary>
+        public TypeSyntax? ReturnType => this.returnType;
+
+        internal override GreenNode? GetSlot(int index)
+            => index switch
+            {
+                0 => this.fnKeyword,
+                1 => this.openParenToken,
+                2 => this.parameters,
+                3 => this.closeParenToken,
+                4 => this.returnType,
+                _ => null,
+            };
+
+        internal override SyntaxNode CreateRed(SyntaxNode? parent, int position) => new CSharp.Syntax.LambdaFunctionTypeSyntax(this, parent, position);
+
+        public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitLambdaFunctionType(this);
+        public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitLambdaFunctionType(this);
+
+        public LambdaFunctionTypeSyntax Update(SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax returnType)
+        {
+            if (fnKeyword != this.FnKeyword || openParenToken != this.OpenParenToken || parameters != this.Parameters || closeParenToken != this.CloseParenToken || returnType != this.ReturnType)
+            {
+                var newNode = SyntaxFactory.LambdaFunctionType(fnKeyword, openParenToken, parameters, closeParenToken, returnType);
+                var diags = GetDiagnostics();
+                if (diags?.Length > 0)
+                    newNode = newNode.WithDiagnosticsGreen(diags);
+                var annotations = GetAnnotations();
+                if (annotations?.Length > 0)
+                    newNode = newNode.WithAnnotationsGreen(annotations);
+                return newNode;
+            }
+
+            return this;
+        }
+
+        internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
+            => new LambdaFunctionTypeSyntax(this.Kind, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, diagnostics, GetAnnotations());
+
+        internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
+            => new LambdaFunctionTypeSyntax(this.Kind, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, GetDiagnostics(), annotations);
+
+        internal LambdaFunctionTypeSyntax(ObjectReader reader)
+          : base(reader)
+        {
+            this.SlotCount = 5;
+            var fnKeyword = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(fnKeyword);
+            this.fnKeyword = fnKeyword;
+            var openParenToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(openParenToken);
+            this.openParenToken = openParenToken;
+            var parameters = (GreenNode?)reader.ReadValue();
+            if (parameters != null)
+            {
+                AdjustFlagsAndWidth(parameters);
+                this.parameters = parameters;
+            }
+            var closeParenToken = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(closeParenToken);
+            this.closeParenToken = closeParenToken;
+            var returnType = (TypeSyntax?)reader.ReadValue();
+            if (returnType != null)
+            {
+                AdjustFlagsAndWidth(returnType);
+                this.returnType = returnType;
+            }
+        }
+
+        internal override void WriteTo(ObjectWriter writer)
+        {
+            base.WriteTo(writer);
+            writer.WriteValue(this.fnKeyword);
+            writer.WriteValue(this.openParenToken);
+            writer.WriteValue(this.parameters);
+            writer.WriteValue(this.closeParenToken);
+            writer.WriteValue(this.returnType);
+        }
+
+        static LambdaFunctionTypeSyntax()
+        {
+            ObjectBinder.RegisterTypeReader(typeof(LambdaFunctionTypeSyntax), r => new LambdaFunctionTypeSyntax(r));
+        }
+    }
+
     internal sealed partial class FunctionPointerTypeSyntax : TypeSyntax
     {
         internal readonly SyntaxToken delegateKeyword;
@@ -32524,6 +32691,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public virtual TResult VisitArrayType(ArrayTypeSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitArrayRankSpecifier(ArrayRankSpecifierSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitPointerType(PointerTypeSyntax node) => this.DefaultVisit(node);
+        public virtual TResult VisitLambdaFunctionType(LambdaFunctionTypeSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitFunctionPointerType(FunctionPointerTypeSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitNullableType(NullableTypeSyntax node) => this.DefaultVisit(node);
         public virtual TResult VisitTupleType(TupleTypeSyntax node) => this.DefaultVisit(node);
@@ -32754,6 +32922,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public virtual void VisitArrayType(ArrayTypeSyntax node) => this.DefaultVisit(node);
         public virtual void VisitArrayRankSpecifier(ArrayRankSpecifierSyntax node) => this.DefaultVisit(node);
         public virtual void VisitPointerType(PointerTypeSyntax node) => this.DefaultVisit(node);
+        public virtual void VisitLambdaFunctionType(LambdaFunctionTypeSyntax node) => this.DefaultVisit(node);
         public virtual void VisitFunctionPointerType(FunctionPointerTypeSyntax node) => this.DefaultVisit(node);
         public virtual void VisitNullableType(NullableTypeSyntax node) => this.DefaultVisit(node);
         public virtual void VisitTupleType(TupleTypeSyntax node) => this.DefaultVisit(node);
@@ -33001,6 +33170,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public override CSharpSyntaxNode VisitPointerType(PointerTypeSyntax node)
             => node.Update((TypeSyntax)Visit(node.ElementType), (SyntaxToken)Visit(node.AsteriskToken));
+
+        public override CSharpSyntaxNode VisitLambdaFunctionType(LambdaFunctionTypeSyntax node)
+            => node.Update((SyntaxToken)Visit(node.FnKeyword), (SyntaxToken)Visit(node.OpenParenToken), VisitList(node.Parameters), (SyntaxToken)Visit(node.CloseParenToken), (TypeSyntax)Visit(node.ReturnType));
 
         public override CSharpSyntaxNode VisitFunctionPointerType(FunctionPointerTypeSyntax node)
             => node.Update((SyntaxToken)Visit(node.DelegateKeyword), (SyntaxToken)Visit(node.AsteriskToken), (SyntaxToken)Visit(node.CallingConvention), (SyntaxToken)Visit(node.LessThanToken), VisitList(node.Parameters), (SyntaxToken)Visit(node.GreaterThanToken));
@@ -33872,6 +34044,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
 
             return result;
+        }
+
+        public LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        {
+#if DEBUG
+            if (fnKeyword == null) throw new ArgumentNullException(nameof(fnKeyword));
+            if (fnKeyword.Kind != SyntaxKind.FnKeyword) throw new ArgumentException(nameof(fnKeyword));
+            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
+            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
+            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+#endif
+
+            return new LambdaFunctionTypeSyntax(SyntaxKind.LambdaFunctionType, fnKeyword, openParenToken, parameters.Node, closeParenToken, returnType, this.context);
         }
 
         public FunctionPointerTypeSyntax FunctionPointerType(SyntaxToken delegateKeyword, SyntaxToken asteriskToken, SyntaxToken? callingConvention, SyntaxToken lessThanToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken greaterThanToken)
@@ -38675,6 +38861,20 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
+        public static LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        {
+#if DEBUG
+            if (fnKeyword == null) throw new ArgumentNullException(nameof(fnKeyword));
+            if (fnKeyword.Kind != SyntaxKind.FnKeyword) throw new ArgumentException(nameof(fnKeyword));
+            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
+            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
+            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+#endif
+
+            return new LambdaFunctionTypeSyntax(SyntaxKind.LambdaFunctionType, fnKeyword, openParenToken, parameters.Node, closeParenToken, returnType);
+        }
+
         public static FunctionPointerTypeSyntax FunctionPointerType(SyntaxToken delegateKeyword, SyntaxToken asteriskToken, SyntaxToken? callingConvention, SyntaxToken lessThanToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken greaterThanToken)
         {
 #if DEBUG
@@ -43272,6 +43472,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 typeof(ArrayTypeSyntax),
                 typeof(ArrayRankSpecifierSyntax),
                 typeof(PointerTypeSyntax),
+                typeof(LambdaFunctionTypeSyntax),
                 typeof(FunctionPointerTypeSyntax),
                 typeof(NullableTypeSyntax),
                 typeof(TupleTypeSyntax),

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -51,6 +51,10 @@ namespace Microsoft.CodeAnalysis.CSharp
         [return: MaybeNull]
         public virtual TResult VisitPointerType(PointerTypeSyntax node) => this.DefaultVisit(node);
 
+        /// <summary>Called when the visitor visits a LambdaFunctionTypeSyntax node.</summary>
+        [return: MaybeNull]
+        public virtual TResult VisitLambdaFunctionType(LambdaFunctionTypeSyntax node) => this.DefaultVisit(node);
+
         /// <summary>Called when the visitor visits a FunctionPointerTypeSyntax node.</summary>
         [return: MaybeNull]
         public virtual TResult VisitFunctionPointerType(FunctionPointerTypeSyntax node) => this.DefaultVisit(node);
@@ -949,6 +953,9 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Called when the visitor visits a PointerTypeSyntax node.</summary>
         public virtual void VisitPointerType(PointerTypeSyntax node) => this.DefaultVisit(node);
 
+        /// <summary>Called when the visitor visits a LambdaFunctionTypeSyntax node.</summary>
+        public virtual void VisitLambdaFunctionType(LambdaFunctionTypeSyntax node) => this.DefaultVisit(node);
+
         /// <summary>Called when the visitor visits a FunctionPointerTypeSyntax node.</summary>
         public virtual void VisitFunctionPointerType(FunctionPointerTypeSyntax node) => this.DefaultVisit(node);
 
@@ -1629,6 +1636,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public override SyntaxNode? VisitPointerType(PointerTypeSyntax node)
             => node.Update((TypeSyntax?)Visit(node.ElementType) ?? throw new ArgumentNullException("elementType"), VisitToken(node.AsteriskToken));
+
+        public override SyntaxNode? VisitLambdaFunctionType(LambdaFunctionTypeSyntax node)
+            => node.Update(VisitToken(node.FnKeyword), VisitToken(node.OpenParenToken), VisitList(node.Parameters), VisitToken(node.CloseParenToken), (TypeSyntax?)Visit(node.ReturnType));
 
         public override SyntaxNode? VisitFunctionPointerType(FunctionPointerTypeSyntax node)
             => node.Update(VisitToken(node.DelegateKeyword), VisitToken(node.AsteriskToken), VisitToken(node.CallingConvention), VisitToken(node.LessThanToken), VisitList(node.Parameters), VisitToken(node.GreaterThanToken));
@@ -2414,6 +2424,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Creates a new PointerTypeSyntax instance.</summary>
         public static PointerTypeSyntax PointerType(TypeSyntax elementType)
             => SyntaxFactory.PointerType(elementType, SyntaxFactory.Token(SyntaxKind.AsteriskToken));
+
+        /// <summary>Creates a new LambdaFunctionTypeSyntax instance.</summary>
+        public static LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken fnKeyword, SyntaxToken openParenToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        {
+            if (fnKeyword.Kind() != SyntaxKind.FnKeyword) throw new ArgumentException(nameof(fnKeyword));
+            if (openParenToken.Kind() != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (closeParenToken.Kind() != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            return (LambdaFunctionTypeSyntax)Syntax.InternalSyntax.SyntaxFactory.LambdaFunctionType((Syntax.InternalSyntax.SyntaxToken)fnKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, parameters.Node.ToGreenSeparatedList<Syntax.InternalSyntax.ParameterSyntax>(), (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!, returnType == null ? null : (Syntax.InternalSyntax.TypeSyntax)returnType.Green).CreateRed();
+        }
+
+        /// <summary>Creates a new LambdaFunctionTypeSyntax instance.</summary>
+        public static LambdaFunctionTypeSyntax LambdaFunctionType(SeparatedSyntaxList<ParameterSyntax> parameters, TypeSyntax? returnType)
+            => SyntaxFactory.LambdaFunctionType(SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseParenToken), returnType);
+
+        /// <summary>Creates a new LambdaFunctionTypeSyntax instance.</summary>
+        public static LambdaFunctionTypeSyntax LambdaFunctionType(SeparatedSyntaxList<ParameterSyntax> parameters = default)
+            => SyntaxFactory.LambdaFunctionType(SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseParenToken), default);
 
         /// <summary>Creates a new FunctionPointerTypeSyntax instance.</summary>
         public static FunctionPointerTypeSyntax FunctionPointerType(SyntaxToken delegateKeyword, SyntaxToken asteriskToken, SyntaxToken callingConvention, SyntaxToken lessThanToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken greaterThanToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -465,6 +465,78 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public PointerTypeSyntax WithAsteriskToken(SyntaxToken asteriskToken) => Update(this.ElementType, asteriskToken);
     }
 
+    public sealed partial class LambdaFunctionTypeSyntax : TypeSyntax
+    {
+        private SyntaxNode? parameters;
+        private TypeSyntax? returnType;
+
+        internal LambdaFunctionTypeSyntax(InternalSyntax.CSharpSyntaxNode green, SyntaxNode? parent, int position)
+          : base(green, parent, position)
+        {
+        }
+
+        /// <summary>SyntaxToken representing the fn keyword.</summary>
+        public SyntaxToken FnKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).fnKeyword, Position, 0);
+
+        /// <summary>Gets the open paren token.</summary>
+        public SyntaxToken OpenParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).openParenToken, GetChildPosition(1), GetChildIndex(1));
+
+        public SeparatedSyntaxList<ParameterSyntax> Parameters
+        {
+            get
+            {
+                var red = GetRed(ref this.parameters, 2);
+                return red != null ? new SeparatedSyntaxList<ParameterSyntax>(red, GetChildIndex(2)) : default;
+            }
+        }
+
+        /// <summary>Gets the close paren token.</summary>
+        public SyntaxToken CloseParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).closeParenToken, GetChildPosition(3), GetChildIndex(3));
+
+        /// <summary>Gets the return type.</summary>
+        public TypeSyntax? ReturnType => GetRed(ref this.returnType, 4);
+
+        internal override SyntaxNode? GetNodeSlot(int index)
+            => index switch
+            {
+                2 => GetRed(ref this.parameters, 2)!,
+                4 => GetRed(ref this.returnType, 4),
+                _ => null,
+            };
+
+        internal override SyntaxNode? GetCachedSlot(int index)
+            => index switch
+            {
+                2 => this.parameters,
+                4 => this.returnType,
+                _ => null,
+            };
+
+        public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitLambdaFunctionType(this);
+        [return: MaybeNull]
+        public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitLambdaFunctionType(this);
+
+        public LambdaFunctionTypeSyntax Update(SyntaxToken fnKeyword, SyntaxToken openParenToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        {
+            if (fnKeyword != this.FnKeyword || openParenToken != this.OpenParenToken || parameters != this.Parameters || closeParenToken != this.CloseParenToken || returnType != this.ReturnType)
+            {
+                var newNode = SyntaxFactory.LambdaFunctionType(fnKeyword, openParenToken, parameters, closeParenToken, returnType);
+                var annotations = GetAnnotations();
+                return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
+            }
+
+            return this;
+        }
+
+        public LambdaFunctionTypeSyntax WithFnKeyword(SyntaxToken fnKeyword) => Update(fnKeyword, this.OpenParenToken, this.Parameters, this.CloseParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithOpenParenToken(SyntaxToken openParenToken) => Update(this.FnKeyword, openParenToken, this.Parameters, this.CloseParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithParameters(SeparatedSyntaxList<ParameterSyntax> parameters) => Update(this.FnKeyword, this.OpenParenToken, parameters, this.CloseParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithCloseParenToken(SyntaxToken closeParenToken) => Update(this.FnKeyword, this.OpenParenToken, this.Parameters, closeParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithReturnType(TypeSyntax? returnType) => Update(this.FnKeyword, this.OpenParenToken, this.Parameters, this.CloseParenToken, returnType);
+
+        public LambdaFunctionTypeSyntax AddParameters(params ParameterSyntax[] items) => WithParameters(this.Parameters.AddRange(items));
+    }
+
     public sealed partial class FunctionPointerTypeSyntax : TypeSyntax
     {
         private SyntaxNode? parameters;

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -50,6 +50,8 @@ Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax.Update(Microsoft.C
 Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax.WithType(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.ColonEqualsToken = 8223 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.DefaultConstraint = 9057 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.FnKeyword = 8445 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.LambdaFunctionType = 9034 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.Modifiers.get -> Microsoft.CodeAnalysis.SyntaxTokenList
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.CommonForEachStatementSyntax.EqualsGreaterThanToken.get -> Microsoft.CodeAnalysis.SyntaxToken
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ToFullString() -> string

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/TypeSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/TypeSyntax.cs
@@ -100,6 +100,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
     }
 
+    internal sealed partial class LambdaFunctionTypeSyntax
+    {
+        internal override TypeSyntax Clone()
+        {
+            return new LambdaFunctionTypeSyntax(this.Kind, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, GetDiagnostics(), GetAnnotations());
+        }
+    }
+
     internal sealed partial class NullableTypeSyntax
     {
         internal override TypeSyntax Clone()

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -223,6 +223,33 @@
       <summary>Creates a PointerTypeSyntax node.</summary>
     </FactoryComment>
   </Node>
+  <Node Name="LambdaFunctionTypeSyntax" Base="TypeSyntax">
+    <Kind Name="LambdaFunctionType"/>
+    <Field Name="FnKeyword" Type="SyntaxToken">
+      <Kind Name="FnKeyword"/>
+      <PropertyComment>
+        <summary>SyntaxToken representing the fn keyword.</summary>
+      </PropertyComment>
+    </Field>
+    <Field Name="OpenParenToken" Type="SyntaxToken">
+      <Kind Name="OpenParenToken"/>
+      <PropertyComment>
+        <summary>Gets the open paren token.</summary>
+      </PropertyComment>
+    </Field>
+    <Field Name="Parameters" Type="SeparatedSyntaxList&lt;ParameterSyntax&gt;" />
+    <Field Name="CloseParenToken" Type="SyntaxToken">
+      <Kind Name="CloseParenToken"/>
+      <PropertyComment>
+        <summary>Gets the close paren token.</summary>
+      </PropertyComment>
+    </Field>
+    <Field Name="ReturnType" Type="TypeSyntax" Optional="true">
+      <PropertyComment>
+        <summary>Gets the return type.</summary>
+      </PropertyComment>
+    </Field>
+  </Node>
   <Node Name="FunctionPointerTypeSyntax" Base="TypeSyntax">
     <Kind Name="FunctionPointerType"/>
     <Field Name="DelegateKeyword" Type="SyntaxToken">

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -206,6 +206,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         WithKeyword = 8442,
         InitKeyword = 8443,
         RecordKeyword = 8444,
+        FnKeyword = 8445,
 
         /// when adding a contextual keyword following functions must be adapted:
         /// <see cref="SyntaxFacts.GetContextualKeywordKinds"/>
@@ -606,6 +607,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         OrPattern = 9031,
         AndPattern = 9032,
         NotPattern = 9033,
+        LambdaFunctionType = 9034,
 
         // Kinds between 9000 and 9039 are "reserved" for pattern matching.
 

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -1092,7 +1092,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static IEnumerable<SyntaxKind> GetContextualKeywordKinds()
         {
-            for (int i = (int)SyntaxKind.YieldKeyword; i <= (int)SyntaxKind.InitKeyword; i++)
+            for (int i = (int)SyntaxKind.YieldKeyword; i <= (int)SyntaxKind.FnKeyword; i++)
             {
                 yield return (SyntaxKind)i;
             }
@@ -1144,6 +1144,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.WithKeyword:
                 case SyntaxKind.InitKeyword:
                 case SyntaxKind.RecordKeyword:
+                case SyntaxKind.FnKeyword:
                     return true;
                 default:
                     return false;
@@ -1261,6 +1262,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SyntaxKind.InitKeyword;
                 case "record":
                     return SyntaxKind.RecordKeyword;
+                case "fn":
+                    return SyntaxKind.FnKeyword;
                 default:
                     return SyntaxKind.None;
             }
@@ -1696,6 +1699,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return "init";
                 case SyntaxKind.RecordKeyword:
                     return "record";
+                case SyntaxKind.FnKeyword:
+                    return "fn";
                 default:
                     return string.Empty;
             }

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -37,6 +37,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private static Syntax.InternalSyntax.PointerTypeSyntax GeneratePointerType()
             => InternalSyntaxFactory.PointerType(GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.AsteriskToken));
 
+        private static Syntax.InternalSyntax.LambdaFunctionTypeSyntax GenerateLambdaFunctionType()
+            => InternalSyntaxFactory.LambdaFunctionType(InternalSyntaxFactory.Token(SyntaxKind.FnKeyword), InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ParameterSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken), null);
+
         private static Syntax.InternalSyntax.FunctionPointerTypeSyntax GenerateFunctionPointerType()
             => InternalSyntaxFactory.FunctionPointerType(InternalSyntaxFactory.Token(SyntaxKind.DelegateKeyword), InternalSyntaxFactory.Token(SyntaxKind.AsteriskToken), null, InternalSyntaxFactory.Token(SyntaxKind.LessThanToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ParameterSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.GreaterThanToken));
 
@@ -787,6 +790,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.NotNull(node.ElementType);
             Assert.Equal(SyntaxKind.AsteriskToken, node.AsteriskToken.Kind);
+
+            AttachAndCheckDiagnostics(node);
+        }
+
+        [Fact]
+        public void TestLambdaFunctionTypeFactoryAndProperties()
+        {
+            var node = GenerateLambdaFunctionType();
+
+            Assert.Equal(SyntaxKind.FnKeyword, node.FnKeyword.Kind);
+            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
+            Assert.Equal(default, node.Parameters);
+            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
+            Assert.Null(node.ReturnType);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -3823,6 +3840,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestPointerTypeIdentityRewriter()
         {
             var oldNode = GeneratePointerType();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestLambdaFunctionTypeTokenDeleteRewriter()
+        {
+            var oldNode = GenerateLambdaFunctionType();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestLambdaFunctionTypeIdentityRewriter()
+        {
+            var oldNode = GenerateLambdaFunctionType();
             var rewriter = new IdentityRewriter();
             var newNode = rewriter.Visit(oldNode);
 
@@ -9503,6 +9546,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         private static PointerTypeSyntax GeneratePointerType()
             => SyntaxFactory.PointerType(GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.AsteriskToken));
 
+        private static LambdaFunctionTypeSyntax GenerateLambdaFunctionType()
+            => SyntaxFactory.LambdaFunctionType(SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), new SeparatedSyntaxList<ParameterSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseParenToken), default(TypeSyntax));
+
         private static FunctionPointerTypeSyntax GenerateFunctionPointerType()
             => SyntaxFactory.FunctionPointerType(SyntaxFactory.Token(SyntaxKind.DelegateKeyword), SyntaxFactory.Token(SyntaxKind.AsteriskToken), default(SyntaxToken), SyntaxFactory.Token(SyntaxKind.LessThanToken), new SeparatedSyntaxList<ParameterSyntax>(), SyntaxFactory.Token(SyntaxKind.GreaterThanToken));
 
@@ -10254,6 +10300,20 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.NotNull(node.ElementType);
             Assert.Equal(SyntaxKind.AsteriskToken, node.AsteriskToken.Kind());
             var newNode = node.WithElementType(node.ElementType).WithAsteriskToken(node.AsteriskToken);
+            Assert.Equal(node, newNode);
+        }
+
+        [Fact]
+        public void TestLambdaFunctionTypeFactoryAndProperties()
+        {
+            var node = GenerateLambdaFunctionType();
+
+            Assert.Equal(SyntaxKind.FnKeyword, node.FnKeyword.Kind());
+            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
+            Assert.Equal(default, node.Parameters);
+            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
+            Assert.Null(node.ReturnType);
+            var newNode = node.WithFnKeyword(node.FnKeyword).WithOpenParenToken(node.OpenParenToken).WithParameters(node.Parameters).WithCloseParenToken(node.CloseParenToken).WithReturnType(node.ReturnType);
             Assert.Equal(node, newNode);
         }
 
@@ -13289,6 +13349,32 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void TestPointerTypeIdentityRewriter()
         {
             var oldNode = GeneratePointerType();
+            var rewriter = new IdentityRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            Assert.Same(oldNode, newNode);
+        }
+
+        [Fact]
+        public void TestLambdaFunctionTypeTokenDeleteRewriter()
+        {
+            var oldNode = GenerateLambdaFunctionType();
+            var rewriter = new TokenDeleteRewriter();
+            var newNode = rewriter.Visit(oldNode);
+
+            if(!oldNode.IsMissing)
+            {
+                Assert.NotEqual(oldNode, newNode);
+            }
+
+            Assert.NotNull(newNode);
+            Assert.True(newNode.IsMissing, "No tokens => missing");
+        }
+
+        [Fact]
+        public void TestLambdaFunctionTypeIdentityRewriter()
+        {
+            var oldNode = GenerateLambdaFunctionType();
             var rewriter = new IdentityRewriter();
             var newNode = rewriter.Visit(oldNode);
 


### PR DESCRIPTION
Adds new syntax for Action/Func types making it more explicit that it's functions.

Enables the following syntax:
`fn() //a function without any parameters and no return type - binds to Action`
`fn()string //a function without any parameters and string as return type - binds to Func<string>`
`fn(string) //a function with a string parameter and no return type - translates to Action<string>`
`fn(string, int)string //a function with two parameters and a return type - translates to Func<string,int,string>`
`fn(name string, age int)string //a function with two parameters and a return type (the "name" and "age" is only for "clarity") - translates to Func<string,int,string>`