### PR TITLE
Feature/async return type inference

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Await.cs
@@ -176,7 +176,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                         {
                             info = method.ReturnsVoid ?
                                 new CSDiagnosticInfo(ErrorCode.ERR_BadAwaitWithoutVoidAsyncMethod) :
-                                new CSDiagnosticInfo(ErrorCode.ERR_BadAwaitWithoutAsyncMethod, method.ReturnType);
+                                (method.ReturnType is null ?
+                                    new CSDiagnosticInfo(ErrorCode.ERR_BadAwaitWithoutAsyncMethod) :
+                                    new CSDiagnosticInfo(ErrorCode.ERR_BadAwaitWithoutAsyncMethod, method.ReturnType));
                         }
                         break;
                 }

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -935,7 +935,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         protected TNode AddLeadingSkippedSyntax<TNode>(TNode node, GreenNode skippedSyntax) where TNode : CSharpSyntaxNode
         {
-            var oldToken = node as SyntaxToken ?? node.GetFirstToken();
+            var oldToken = node as SyntaxToken ?? node.GetFirstNonZeroWidthToken();
             var newToken = AddSkippedSyntax(oldToken, skippedSyntax, trailing: false);
             return SyntaxFirstTokenReplacer.Replace(node, oldToken, newToken, skippedSyntax.FullWidth);
         }
@@ -960,9 +960,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             else
             {
-                var lastToken = node.GetLastToken();
+                var lastToken = node.GetLastNonZeroWidthToken();
                 var newToken = AddSkippedSyntax(lastToken, skippedSyntax, trailing: true);
-                return SyntaxLastTokenReplacer.Replace(node, newToken);
+                return SyntaxLastTokenReplacer.Replace(node, newToken, lastToken);
             }
         }
 

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/CSharpSyntaxNode.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/CSharpSyntaxNode.cs
@@ -118,9 +118,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return (SyntaxToken)this.GetFirstTerminal();
         }
 
+        public SyntaxToken GetFirstNonZeroWidthToken()
+        {
+            return (SyntaxToken)this.GetFirstTerminal();
+        }
+
         public SyntaxToken GetLastToken()
         {
             return (SyntaxToken)this.GetLastTerminal();
+        }
+
+        public SyntaxToken GetLastNonZeroWidthToken()
+        {
+            return (SyntaxToken)this.GetLastNonZeroWidthTerminal();
         }
 
         public SyntaxToken GetLastNonmissingToken()

--- a/src/Compilers/Core/Portable/Syntax/GreenNode.cs
+++ b/src/Compilers/Core/Portable/Syntax/GreenNode.cs
@@ -795,6 +795,28 @@ namespace Microsoft.CodeAnalysis
             return node;
         }
 
+        internal GreenNode? GetFirstNonZeroWidthTerminal()
+        {
+            GreenNode? node = this;
+
+            do
+            {
+                GreenNode? firstChild = null;
+                for (int i = 0, n = node.SlotCount; i < n; i++)
+                {
+                    var child = node.GetSlot(i);
+                    if (child != null && child.Width > 0)
+                    {
+                        firstChild = child;
+                        break;
+                    }
+                }
+                node = firstChild;
+            } while (node?._slotCount > 0);
+
+            return node;
+        }
+
         internal GreenNode? GetLastTerminal()
         {
             GreenNode? node = this;
@@ -806,6 +828,28 @@ namespace Microsoft.CodeAnalysis
                 {
                     var child = node.GetSlot(i);
                     if (child != null)
+                    {
+                        lastChild = child;
+                        break;
+                    }
+                }
+                node = lastChild;
+            } while (node?._slotCount > 0);
+
+            return node;
+        }
+
+        internal GreenNode? GetLastNonZeroWidthTerminal()
+        {
+            GreenNode? node = this;
+
+            do
+            {
+                GreenNode? lastChild = null;
+                for (int i = node.SlotCount - 1; i >= 0; i--)
+                {
+                    var child = node.GetSlot(i);
+                    if (child != null && child.Width > 0)
                     {
                         lastChild = child;
                         break;

--- a/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxTreeExtensions.cs
@@ -34,9 +34,15 @@ namespace Microsoft.CodeAnalysis
                 if (change != fullSpan)
                 {
                     // Find the lowest node in the tree that contains the changed region.
+#if DEBUG
+                    var allDescendants = root.DescendantNodes().ToList();
+                    var descendants = root.DescendantNodes(n => n.FullSpan.Contains(change)).ToList();
+                    node = descendants.LastOrDefault(n => n.FullSpan.Contains(change));
+#else
                     node = root
                         .DescendantNodes(n => n.FullSpan.Contains(change))
                         .LastOrDefault(n => n.FullSpan.Contains(change));
+#endif
                 }
             }
 


### PR DESCRIPTION
Adds return type inference for async methods - making it easier to declare async methods without having to explicitly return the Task type.

Enables syntax like:
`async MyMethod() string { return "test" } // method without explicit Task<string> as return type, it's inferred anyway`