### PR TITLE
Feature/async return type inference for await expressions

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/Helpers/AwaitExpressionSyntaxFinder.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Helpers/AwaitExpressionSyntaxFinder.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
+{
+    internal sealed class AwaitExpressionsInternalSyntaxFinder : CSharpInternalSyntaxWalker
+    {
+        public bool HasValidAwaitExpressions { get; private set; }
+
+        public static bool HasNonNestedAwaitExpressions(CSharpSyntaxNode node)
+        {
+            if (node == null) return false;
+            var visitor = new AwaitExpressionsInternalSyntaxFinder();
+            visitor.Visit(node);
+            return visitor.HasValidAwaitExpressions;
+        }
+
+        public override void Visit(CSharpSyntaxNode node)
+        {
+            if (node is LambdaExpressionSyntax) return;
+
+            base.Visit(node);
+        }
+
+        public override void VisitAnonymousMethodExpression(AnonymousMethodExpressionSyntax node)
+        {
+            // Do not returse into local lambdas ... 
+        }
+
+        public override void VisitParenthesizedLambdaExpression(ParenthesizedLambdaExpressionSyntax node)
+        {
+            // Do not returse into local lambdas ... 
+        }
+
+        public override void VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax node)
+        {
+            // Do not returse into local lambdas ... 
+        }
+
+        public override void VisitLocalFunctionStatement(LocalFunctionStatementSyntax node)
+        {
+            // Do not recurse into local functions ...
+        }
+
+        public override void VisitAwaitExpression(AwaitExpressionSyntax node)
+        {
+            HasValidAwaitExpressions = true;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/CSharpSyntaxWalker.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/CSharpSyntaxWalker.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
+{
+    internal abstract class CSharpInternalSyntaxWalker : CSharpSyntaxVisitor
+    {
+        protected SyntaxWalkerDepth Depth { get; }
+
+        protected CSharpInternalSyntaxWalker(SyntaxWalkerDepth depth = SyntaxWalkerDepth.Node)
+        {
+            this.Depth = depth;
+        }
+
+        private int _recursionDepth;
+
+        public override void Visit(CSharpSyntaxNode node)
+        {
+            if (node != null)
+            {
+                _recursionDepth++;
+                StackGuard.EnsureSufficientExecutionStack(_recursionDepth);
+
+                node.Accept(this);
+
+                _recursionDepth--;
+            }
+        }
+
+        public override void DefaultVisit(CSharpSyntaxNode node)
+        {
+            if (node == null) return;
+
+            foreach (var child in node.ChildNodesAndTokens())
+            {
+                if (child.IsToken && child is SyntaxToken token)
+                {
+                    this.VisitToken(token);
+                }
+                else if (child is CSharpSyntaxNode childNode)
+                {
+                    this.Visit(childNode);
+                }
+            }
+        }
+
+        public override void VisitToken(SyntaxToken token)
+        {
+        }
+
+        public override void VisitTrivia(SyntaxTrivia trivia)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Updates syntax to allow using "await SomeAsyncCall()" inside lambda bodies without the need to declare the lambda as "async" - it is automatically inferred.

Enables syntax like:
`DoSomethingAsyncWithCallback(=>await MyAsyncOperation()) // can await without the 'async'`

`DoSomethingAsyncWithCallback({ await MyAsyncOperation() }) // can await without the 'async'`