### PR TITLE
Feature/async lambda type declaration

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -363,7 +363,7 @@ function_pointer_type
   ;
 
 lambda_function_type
-  : fn_keyword '(' (parameter (',' parameter)*)? ')' type?
+  : 'async'? 'fn' '(' (parameter (',' parameter)*)? ')' type?
   ;
 
 nullable_type
@@ -1281,10 +1281,6 @@ character_literal_token
 expression_or_pattern
   : expression
   | pattern
-  ;
-
-fn_keyword
-  : /* see lexical specification */
   ;
 
 identifier_token

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -1051,16 +1051,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal sealed partial class LambdaFunctionTypeSyntax : TypeSyntax
     {
+        internal readonly SyntaxToken? asyncModifier;
         internal readonly SyntaxToken fnKeyword;
         internal readonly SyntaxToken openParenToken;
         internal readonly GreenNode? parameters;
         internal readonly SyntaxToken closeParenToken;
         internal readonly TypeSyntax? returnType;
 
-        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken? asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
-            this.SlotCount = 5;
+            this.SlotCount = 6;
+            if (asyncModifier != null)
+            {
+                this.AdjustFlagsAndWidth(asyncModifier);
+                this.asyncModifier = asyncModifier;
+            }
             this.AdjustFlagsAndWidth(fnKeyword);
             this.fnKeyword = fnKeyword;
             this.AdjustFlagsAndWidth(openParenToken);
@@ -1079,11 +1085,16 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType, SyntaxFactoryContext context)
+        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken? asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
-            this.SlotCount = 5;
+            this.SlotCount = 6;
+            if (asyncModifier != null)
+            {
+                this.AdjustFlagsAndWidth(asyncModifier);
+                this.asyncModifier = asyncModifier;
+            }
             this.AdjustFlagsAndWidth(fnKeyword);
             this.fnKeyword = fnKeyword;
             this.AdjustFlagsAndWidth(openParenToken);
@@ -1102,10 +1113,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        internal LambdaFunctionTypeSyntax(SyntaxKind kind, SyntaxToken? asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, GreenNode? parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
           : base(kind)
         {
-            this.SlotCount = 5;
+            this.SlotCount = 6;
+            if (asyncModifier != null)
+            {
+                this.AdjustFlagsAndWidth(asyncModifier);
+                this.asyncModifier = asyncModifier;
+            }
             this.AdjustFlagsAndWidth(fnKeyword);
             this.fnKeyword = fnKeyword;
             this.AdjustFlagsAndWidth(openParenToken);
@@ -1124,6 +1140,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
+        /// <summary>SyntaxToken representing the async modifier keyword.</summary>
+        public SyntaxToken? AsyncModifier => this.asyncModifier;
         /// <summary>SyntaxToken representing the fn keyword.</summary>
         public SyntaxToken FnKeyword => this.fnKeyword;
         /// <summary>Gets the open paren token.</summary>
@@ -1137,11 +1155,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         internal override GreenNode? GetSlot(int index)
             => index switch
             {
-                0 => this.fnKeyword,
-                1 => this.openParenToken,
-                2 => this.parameters,
-                3 => this.closeParenToken,
-                4 => this.returnType,
+                0 => this.asyncModifier,
+                1 => this.fnKeyword,
+                2 => this.openParenToken,
+                3 => this.parameters,
+                4 => this.closeParenToken,
+                5 => this.returnType,
                 _ => null,
             };
 
@@ -1150,11 +1169,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitLambdaFunctionType(this);
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitLambdaFunctionType(this);
 
-        public LambdaFunctionTypeSyntax Update(SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax returnType)
+        public LambdaFunctionTypeSyntax Update(SyntaxToken asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax returnType)
         {
-            if (fnKeyword != this.FnKeyword || openParenToken != this.OpenParenToken || parameters != this.Parameters || closeParenToken != this.CloseParenToken || returnType != this.ReturnType)
+            if (asyncModifier != this.AsyncModifier || fnKeyword != this.FnKeyword || openParenToken != this.OpenParenToken || parameters != this.Parameters || closeParenToken != this.CloseParenToken || returnType != this.ReturnType)
             {
-                var newNode = SyntaxFactory.LambdaFunctionType(fnKeyword, openParenToken, parameters, closeParenToken, returnType);
+                var newNode = SyntaxFactory.LambdaFunctionType(asyncModifier, fnKeyword, openParenToken, parameters, closeParenToken, returnType);
                 var diags = GetDiagnostics();
                 if (diags?.Length > 0)
                     newNode = newNode.WithDiagnosticsGreen(diags);
@@ -1168,15 +1187,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-            => new LambdaFunctionTypeSyntax(this.Kind, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, diagnostics, GetAnnotations());
+            => new LambdaFunctionTypeSyntax(this.Kind, this.asyncModifier, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, diagnostics, GetAnnotations());
 
         internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-            => new LambdaFunctionTypeSyntax(this.Kind, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, GetDiagnostics(), annotations);
+            => new LambdaFunctionTypeSyntax(this.Kind, this.asyncModifier, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, GetDiagnostics(), annotations);
 
         internal LambdaFunctionTypeSyntax(ObjectReader reader)
           : base(reader)
         {
-            this.SlotCount = 5;
+            this.SlotCount = 6;
+            var asyncModifier = (SyntaxToken?)reader.ReadValue();
+            if (asyncModifier != null)
+            {
+                AdjustFlagsAndWidth(asyncModifier);
+                this.asyncModifier = asyncModifier;
+            }
             var fnKeyword = (SyntaxToken)reader.ReadValue();
             AdjustFlagsAndWidth(fnKeyword);
             this.fnKeyword = fnKeyword;
@@ -1203,6 +1228,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         internal override void WriteTo(ObjectWriter writer)
         {
             base.WriteTo(writer);
+            writer.WriteValue(this.asyncModifier);
             writer.WriteValue(this.fnKeyword);
             writer.WriteValue(this.openParenToken);
             writer.WriteValue(this.parameters);
@@ -33172,7 +33198,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             => node.Update((TypeSyntax)Visit(node.ElementType), (SyntaxToken)Visit(node.AsteriskToken));
 
         public override CSharpSyntaxNode VisitLambdaFunctionType(LambdaFunctionTypeSyntax node)
-            => node.Update((SyntaxToken)Visit(node.FnKeyword), (SyntaxToken)Visit(node.OpenParenToken), VisitList(node.Parameters), (SyntaxToken)Visit(node.CloseParenToken), (TypeSyntax)Visit(node.ReturnType));
+            => node.Update((SyntaxToken)Visit(node.AsyncModifier), (SyntaxToken)Visit(node.FnKeyword), (SyntaxToken)Visit(node.OpenParenToken), VisitList(node.Parameters), (SyntaxToken)Visit(node.CloseParenToken), (TypeSyntax)Visit(node.ReturnType));
 
         public override CSharpSyntaxNode VisitFunctionPointerType(FunctionPointerTypeSyntax node)
             => node.Update((SyntaxToken)Visit(node.DelegateKeyword), (SyntaxToken)Visit(node.AsteriskToken), (SyntaxToken)Visit(node.CallingConvention), (SyntaxToken)Visit(node.LessThanToken), VisitList(node.Parameters), (SyntaxToken)Visit(node.GreaterThanToken));
@@ -34046,9 +34072,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        public LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken? asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
         {
 #if DEBUG
+            if (asyncModifier != null)
+            {
+                switch (asyncModifier.Kind)
+                {
+                    case SyntaxKind.AsyncKeyword:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(asyncModifier));
+                }
+            }
             if (fnKeyword == null) throw new ArgumentNullException(nameof(fnKeyword));
             if (fnKeyword.Kind != SyntaxKind.FnKeyword) throw new ArgumentException(nameof(fnKeyword));
             if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
@@ -34057,7 +34092,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
 #endif
 
-            return new LambdaFunctionTypeSyntax(SyntaxKind.LambdaFunctionType, fnKeyword, openParenToken, parameters.Node, closeParenToken, returnType, this.context);
+            return new LambdaFunctionTypeSyntax(SyntaxKind.LambdaFunctionType, asyncModifier, fnKeyword, openParenToken, parameters.Node, closeParenToken, returnType, this.context);
         }
 
         public FunctionPointerTypeSyntax FunctionPointerType(SyntaxToken delegateKeyword, SyntaxToken asteriskToken, SyntaxToken? callingConvention, SyntaxToken lessThanToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken greaterThanToken)
@@ -38861,9 +38896,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public static LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        public static LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken? asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
         {
 #if DEBUG
+            if (asyncModifier != null)
+            {
+                switch (asyncModifier.Kind)
+                {
+                    case SyntaxKind.AsyncKeyword:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(asyncModifier));
+                }
+            }
             if (fnKeyword == null) throw new ArgumentNullException(nameof(fnKeyword));
             if (fnKeyword.Kind != SyntaxKind.FnKeyword) throw new ArgumentException(nameof(fnKeyword));
             if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
@@ -38872,7 +38916,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
 #endif
 
-            return new LambdaFunctionTypeSyntax(SyntaxKind.LambdaFunctionType, fnKeyword, openParenToken, parameters.Node, closeParenToken, returnType);
+            return new LambdaFunctionTypeSyntax(SyntaxKind.LambdaFunctionType, asyncModifier, fnKeyword, openParenToken, parameters.Node, closeParenToken, returnType);
         }
 
         public static FunctionPointerTypeSyntax FunctionPointerType(SyntaxToken delegateKeyword, SyntaxToken asteriskToken, SyntaxToken? callingConvention, SyntaxToken lessThanToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken greaterThanToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -1638,7 +1638,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => node.Update((TypeSyntax?)Visit(node.ElementType) ?? throw new ArgumentNullException("elementType"), VisitToken(node.AsteriskToken));
 
         public override SyntaxNode? VisitLambdaFunctionType(LambdaFunctionTypeSyntax node)
-            => node.Update(VisitToken(node.FnKeyword), VisitToken(node.OpenParenToken), VisitList(node.Parameters), VisitToken(node.CloseParenToken), (TypeSyntax?)Visit(node.ReturnType));
+            => node.Update(VisitToken(node.AsyncModifier), VisitToken(node.FnKeyword), VisitToken(node.OpenParenToken), VisitList(node.Parameters), VisitToken(node.CloseParenToken), (TypeSyntax?)Visit(node.ReturnType));
 
         public override SyntaxNode? VisitFunctionPointerType(FunctionPointerTypeSyntax node)
             => node.Update(VisitToken(node.DelegateKeyword), VisitToken(node.AsteriskToken), VisitToken(node.CallingConvention), VisitToken(node.LessThanToken), VisitList(node.Parameters), VisitToken(node.GreaterThanToken));
@@ -2426,21 +2426,27 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SyntaxFactory.PointerType(elementType, SyntaxFactory.Token(SyntaxKind.AsteriskToken));
 
         /// <summary>Creates a new LambdaFunctionTypeSyntax instance.</summary>
-        public static LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken fnKeyword, SyntaxToken openParenToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        public static LambdaFunctionTypeSyntax LambdaFunctionType(SyntaxToken asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
         {
+            switch (asyncModifier.Kind())
+            {
+                case SyntaxKind.AsyncKeyword:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(asyncModifier));
+            }
             if (fnKeyword.Kind() != SyntaxKind.FnKeyword) throw new ArgumentException(nameof(fnKeyword));
             if (openParenToken.Kind() != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
             if (closeParenToken.Kind() != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
-            return (LambdaFunctionTypeSyntax)Syntax.InternalSyntax.SyntaxFactory.LambdaFunctionType((Syntax.InternalSyntax.SyntaxToken)fnKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, parameters.Node.ToGreenSeparatedList<Syntax.InternalSyntax.ParameterSyntax>(), (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!, returnType == null ? null : (Syntax.InternalSyntax.TypeSyntax)returnType.Green).CreateRed();
+            return (LambdaFunctionTypeSyntax)Syntax.InternalSyntax.SyntaxFactory.LambdaFunctionType((Syntax.InternalSyntax.SyntaxToken?)asyncModifier.Node, (Syntax.InternalSyntax.SyntaxToken)fnKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, parameters.Node.ToGreenSeparatedList<Syntax.InternalSyntax.ParameterSyntax>(), (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!, returnType == null ? null : (Syntax.InternalSyntax.TypeSyntax)returnType.Green).CreateRed();
         }
 
         /// <summary>Creates a new LambdaFunctionTypeSyntax instance.</summary>
         public static LambdaFunctionTypeSyntax LambdaFunctionType(SeparatedSyntaxList<ParameterSyntax> parameters, TypeSyntax? returnType)
-            => SyntaxFactory.LambdaFunctionType(SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseParenToken), returnType);
+            => SyntaxFactory.LambdaFunctionType(default, SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseParenToken), returnType);
 
         /// <summary>Creates a new LambdaFunctionTypeSyntax instance.</summary>
         public static LambdaFunctionTypeSyntax LambdaFunctionType(SeparatedSyntaxList<ParameterSyntax> parameters = default)
-            => SyntaxFactory.LambdaFunctionType(SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseParenToken), default);
+            => SyntaxFactory.LambdaFunctionType(default, SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseParenToken), default);
 
         /// <summary>Creates a new FunctionPointerTypeSyntax instance.</summary>
         public static FunctionPointerTypeSyntax FunctionPointerType(SyntaxToken delegateKeyword, SyntaxToken asteriskToken, SyntaxToken callingConvention, SyntaxToken lessThanToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken greaterThanToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -475,40 +475,50 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
         }
 
+        /// <summary>SyntaxToken representing the async modifier keyword.</summary>
+        public SyntaxToken AsyncModifier
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).asyncModifier;
+                return slot != null ? new SyntaxToken(this, slot, Position, 0) : default;
+            }
+        }
+
         /// <summary>SyntaxToken representing the fn keyword.</summary>
-        public SyntaxToken FnKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).fnKeyword, Position, 0);
+        public SyntaxToken FnKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).fnKeyword, GetChildPosition(1), GetChildIndex(1));
 
         /// <summary>Gets the open paren token.</summary>
-        public SyntaxToken OpenParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).openParenToken, GetChildPosition(1), GetChildIndex(1));
+        public SyntaxToken OpenParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).openParenToken, GetChildPosition(2), GetChildIndex(2));
 
         public SeparatedSyntaxList<ParameterSyntax> Parameters
         {
             get
             {
-                var red = GetRed(ref this.parameters, 2);
-                return red != null ? new SeparatedSyntaxList<ParameterSyntax>(red, GetChildIndex(2)) : default;
+                var red = GetRed(ref this.parameters, 3);
+                return red != null ? new SeparatedSyntaxList<ParameterSyntax>(red, GetChildIndex(3)) : default;
             }
         }
 
         /// <summary>Gets the close paren token.</summary>
-        public SyntaxToken CloseParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).closeParenToken, GetChildPosition(3), GetChildIndex(3));
+        public SyntaxToken CloseParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.LambdaFunctionTypeSyntax)this.Green).closeParenToken, GetChildPosition(4), GetChildIndex(4));
 
         /// <summary>Gets the return type.</summary>
-        public TypeSyntax? ReturnType => GetRed(ref this.returnType, 4);
+        public TypeSyntax? ReturnType => GetRed(ref this.returnType, 5);
 
         internal override SyntaxNode? GetNodeSlot(int index)
             => index switch
             {
-                2 => GetRed(ref this.parameters, 2)!,
-                4 => GetRed(ref this.returnType, 4),
+                3 => GetRed(ref this.parameters, 3)!,
+                5 => GetRed(ref this.returnType, 5),
                 _ => null,
             };
 
         internal override SyntaxNode? GetCachedSlot(int index)
             => index switch
             {
-                2 => this.parameters,
-                4 => this.returnType,
+                3 => this.parameters,
+                5 => this.returnType,
                 _ => null,
             };
 
@@ -516,11 +526,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         [return: MaybeNull]
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitLambdaFunctionType(this);
 
-        public LambdaFunctionTypeSyntax Update(SyntaxToken fnKeyword, SyntaxToken openParenToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
+        public LambdaFunctionTypeSyntax Update(SyntaxToken asyncModifier, SyntaxToken fnKeyword, SyntaxToken openParenToken, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxToken closeParenToken, TypeSyntax? returnType)
         {
-            if (fnKeyword != this.FnKeyword || openParenToken != this.OpenParenToken || parameters != this.Parameters || closeParenToken != this.CloseParenToken || returnType != this.ReturnType)
+            if (asyncModifier != this.AsyncModifier || fnKeyword != this.FnKeyword || openParenToken != this.OpenParenToken || parameters != this.Parameters || closeParenToken != this.CloseParenToken || returnType != this.ReturnType)
             {
-                var newNode = SyntaxFactory.LambdaFunctionType(fnKeyword, openParenToken, parameters, closeParenToken, returnType);
+                var newNode = SyntaxFactory.LambdaFunctionType(asyncModifier, fnKeyword, openParenToken, parameters, closeParenToken, returnType);
                 var annotations = GetAnnotations();
                 return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
             }
@@ -528,11 +538,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return this;
         }
 
-        public LambdaFunctionTypeSyntax WithFnKeyword(SyntaxToken fnKeyword) => Update(fnKeyword, this.OpenParenToken, this.Parameters, this.CloseParenToken, this.ReturnType);
-        public LambdaFunctionTypeSyntax WithOpenParenToken(SyntaxToken openParenToken) => Update(this.FnKeyword, openParenToken, this.Parameters, this.CloseParenToken, this.ReturnType);
-        public LambdaFunctionTypeSyntax WithParameters(SeparatedSyntaxList<ParameterSyntax> parameters) => Update(this.FnKeyword, this.OpenParenToken, parameters, this.CloseParenToken, this.ReturnType);
-        public LambdaFunctionTypeSyntax WithCloseParenToken(SyntaxToken closeParenToken) => Update(this.FnKeyword, this.OpenParenToken, this.Parameters, closeParenToken, this.ReturnType);
-        public LambdaFunctionTypeSyntax WithReturnType(TypeSyntax? returnType) => Update(this.FnKeyword, this.OpenParenToken, this.Parameters, this.CloseParenToken, returnType);
+        public LambdaFunctionTypeSyntax WithAsyncModifier(SyntaxToken asyncModifier) => Update(asyncModifier, this.FnKeyword, this.OpenParenToken, this.Parameters, this.CloseParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithFnKeyword(SyntaxToken fnKeyword) => Update(this.AsyncModifier, fnKeyword, this.OpenParenToken, this.Parameters, this.CloseParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithOpenParenToken(SyntaxToken openParenToken) => Update(this.AsyncModifier, this.FnKeyword, openParenToken, this.Parameters, this.CloseParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithParameters(SeparatedSyntaxList<ParameterSyntax> parameters) => Update(this.AsyncModifier, this.FnKeyword, this.OpenParenToken, parameters, this.CloseParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithCloseParenToken(SyntaxToken closeParenToken) => Update(this.AsyncModifier, this.FnKeyword, this.OpenParenToken, this.Parameters, closeParenToken, this.ReturnType);
+        public LambdaFunctionTypeSyntax WithReturnType(TypeSyntax? returnType) => Update(this.AsyncModifier, this.FnKeyword, this.OpenParenToken, this.Parameters, this.CloseParenToken, returnType);
 
         public LambdaFunctionTypeSyntax AddParameters(params ParameterSyntax[] items) => WithParameters(this.Parameters.AddRange(items));
     }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceOrdinaryMethodSymbol.cs
@@ -172,33 +172,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // make sure that the return type of the method is "Task" for async declarations, and if its not - synthesize the Task<...> type
             if (IsAsync)
             {
-                if (returnType.Type?.Name?.StartsWith("Task") != true)
-                {
-                    if (returnType.Type.IsErrorType())
-                    {
-                        // we have an error type ... probably failed to infer the type from the body ... lets just wrap it with the Task<...> type ...
-                        var taskTypeT = signatureBinder.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T, diagnostics, returnTypeSyntax);
-                        var returnTaskTypeT = taskTypeT.Construct(ImmutableArray.Create(returnType));
-                        returnType = TypeWithAnnotations.Create(returnTaskTypeT);
-                    }
-                    else
-                    {
-                        // we have a valid type
-                        if (returnType.Type.IsVoidType())
-                        {
-                            // just use the Task type for 'void' ...
-                            var taskType = signatureBinder.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task, diagnostics, returnTypeSyntax);
-                            returnType = TypeWithAnnotations.Create(taskType);
-                        }
-                        else
-                        {
-                            // lets just wrap it with the Task<...> type...
-                            var taskTypeT = signatureBinder.GetWellKnownType(WellKnownType.System_Threading_Tasks_Task_T, diagnostics, returnTypeSyntax);
-                            var returnTaskTypeT = taskTypeT.Construct(ImmutableArray.Create(returnType));
-                            returnType = TypeWithAnnotations.Create(returnTaskTypeT);
-                        }
-                    }
-                }
+                returnType = signatureBinder.BindAsTaskType(returnType, diagnostics, returnTypeSyntax);
             }
 
             // span-like types are returnable in general

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.FakeTokenWithTrivia.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.FakeTokenWithTrivia.cs
@@ -73,6 +73,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal static class FakeSyntaxTokenExtensions
     {
+        internal static bool IsContextKind(this SyntaxToken token, SyntaxKind contextKind, SyntaxKind? kind = null)
+        {
+            if (token == null) return false;
+            if (kind != null && kind.Value != token.Kind) return false;
+            return token.ContextualKind == contextKind;
+        }
+
         internal static bool IsFakeToken(this SyntaxToken token)
         {
             return token is SyntaxToken.FakeTokenWithTrivia;

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/TypeSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/TypeSyntax.cs
@@ -104,7 +104,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     {
         internal override TypeSyntax Clone()
         {
-            return new LambdaFunctionTypeSyntax(this.Kind, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, GetDiagnostics(), GetAnnotations());
+            return new LambdaFunctionTypeSyntax(this.Kind, this.asyncModifier, this.fnKeyword, this.openParenToken, this.parameters, this.closeParenToken, this.returnType, GetDiagnostics(), GetAnnotations());
         }
     }
 

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -225,6 +225,12 @@
   </Node>
   <Node Name="LambdaFunctionTypeSyntax" Base="TypeSyntax">
     <Kind Name="LambdaFunctionType"/>
+    <Field Name="AsyncModifier" Type="SyntaxToken" Optional="true">
+      <Kind Name="AsyncKeyword"/>
+      <PropertyComment>
+        <summary>SyntaxToken representing the async modifier keyword.</summary>
+      </PropertyComment>
+    </Field>
     <Field Name="FnKeyword" Type="SyntaxToken">
       <Kind Name="FnKeyword"/>
       <PropertyComment>

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -38,7 +38,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.PointerType(GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.AsteriskToken));
 
         private static Syntax.InternalSyntax.LambdaFunctionTypeSyntax GenerateLambdaFunctionType()
-            => InternalSyntaxFactory.LambdaFunctionType(InternalSyntaxFactory.Token(SyntaxKind.FnKeyword), InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ParameterSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken), null);
+            => InternalSyntaxFactory.LambdaFunctionType(null, InternalSyntaxFactory.Token(SyntaxKind.FnKeyword), InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ParameterSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken), null);
 
         private static Syntax.InternalSyntax.FunctionPointerTypeSyntax GenerateFunctionPointerType()
             => InternalSyntaxFactory.FunctionPointerType(InternalSyntaxFactory.Token(SyntaxKind.DelegateKeyword), InternalSyntaxFactory.Token(SyntaxKind.AsteriskToken), null, InternalSyntaxFactory.Token(SyntaxKind.LessThanToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ParameterSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.GreaterThanToken));
@@ -799,6 +799,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateLambdaFunctionType();
 
+            Assert.Null(node.AsyncModifier);
             Assert.Equal(SyntaxKind.FnKeyword, node.FnKeyword.Kind);
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
             Assert.Equal(default, node.Parameters);
@@ -9547,7 +9548,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.PointerType(GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.AsteriskToken));
 
         private static LambdaFunctionTypeSyntax GenerateLambdaFunctionType()
-            => SyntaxFactory.LambdaFunctionType(SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), new SeparatedSyntaxList<ParameterSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseParenToken), default(TypeSyntax));
+            => SyntaxFactory.LambdaFunctionType(default(SyntaxToken), SyntaxFactory.Token(SyntaxKind.FnKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), new SeparatedSyntaxList<ParameterSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseParenToken), default(TypeSyntax));
 
         private static FunctionPointerTypeSyntax GenerateFunctionPointerType()
             => SyntaxFactory.FunctionPointerType(SyntaxFactory.Token(SyntaxKind.DelegateKeyword), SyntaxFactory.Token(SyntaxKind.AsteriskToken), default(SyntaxToken), SyntaxFactory.Token(SyntaxKind.LessThanToken), new SeparatedSyntaxList<ParameterSyntax>(), SyntaxFactory.Token(SyntaxKind.GreaterThanToken));
@@ -10308,12 +10309,13 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateLambdaFunctionType();
 
+            Assert.Equal(SyntaxKind.None, node.AsyncModifier.Kind());
             Assert.Equal(SyntaxKind.FnKeyword, node.FnKeyword.Kind());
             Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
             Assert.Equal(default, node.Parameters);
             Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
             Assert.Null(node.ReturnType);
-            var newNode = node.WithFnKeyword(node.FnKeyword).WithOpenParenToken(node.OpenParenToken).WithParameters(node.Parameters).WithCloseParenToken(node.CloseParenToken).WithReturnType(node.ReturnType);
+            var newNode = node.WithAsyncModifier(node.AsyncModifier).WithFnKeyword(node.FnKeyword).WithOpenParenToken(node.OpenParenToken).WithParameters(node.Parameters).WithCloseParenToken(node.CloseParenToken).WithReturnType(node.ReturnType);
             Assert.Equal(node, newNode);
         }
 


### PR DESCRIPTION
Updates lambda type declarations to allow explicit syntax for "async" lambdas - which in turn bind to Action / Func with Task as return types - making the syntax nicer to "read".

Enables the following syntax:
`MyMethod(asyncCallback async fn()) {} // asyncCallback binds to an Action<Task>`
`MyMethod(asyncCallback async fn(int)) {} // asyncCallback binds to an Action<int, Task>`
`MyMethod(asyncCallback async fn() string) {} // asyncCallback binds to an Func<Task<string>>`
`MyMethod(asyncCallback async fn(int) string) {} // asyncCallback binds to an Func<Task<int, string>>`