### PR TITLE
Feature/method decl trailing catch finally

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1758,7 +1758,16 @@ namespace Microsoft.CodeAnalysis.CSharp
                 boundStatements.Add(boundStatement);
             }
 
-            return FinishBindBlockParts(node, boundStatements.ToImmutableAndFree(), diagnostics);
+            var block = FinishBindBlockParts(node, boundStatements.ToImmutableAndFree(), diagnostics);
+
+            // this is most likely a "fake block" wrapping a statement...
+            if (node.TryGetInlineStatement(out var inlineStatement))
+            {
+                // bind to the inner statement of the block!
+                block = new BoundBlock(inlineStatement, block.Locals, block.Statements) { WasCompilerGenerated = true };
+            }
+
+            return block;
         }
 
         private BoundBlock FinishBindBlockParts(CSharpSyntaxNode node, ImmutableArray<BoundStatement> boundStatements, DiagnosticBag diagnostics)

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1761,7 +1761,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             var block = FinishBindBlockParts(node, boundStatements.ToImmutableAndFree(), diagnostics);
 
             // this is most likely a "fake block" wrapping a statement...
-            if (node.TryGetInlineStatement(out var inlineStatement))
+            if (node.TryGetInlineBlockStatement(out var inlineStatement))
             {
                 // bind to the inner statement of the block!
                 block = new BoundBlock(inlineStatement, block.Locals, block.Statements) { WasCompilerGenerated = true };

--- a/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/LocalScopeBinder.cs
@@ -15,9 +15,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 {
     internal partial class LocalScopeBinder : Binder
     {
-        private ImmutableArray<LocalSymbol> _locals;
-        private ImmutableArray<LocalFunctionSymbol> _localFunctions;
-        private ImmutableArray<LabelSymbol> _labels;
+        protected ImmutableArray<LocalSymbol> _locals;
+        protected ImmutableArray<LocalFunctionSymbol> _localFunctions;
+        protected ImmutableArray<LabelSymbol> _labels;
         private readonly uint _localScopeDepth;
 
         internal LocalScopeBinder(Binder next)

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -5,7 +5,9 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection.Metadata;
+using System.Resources;
 using Microsoft.CodeAnalysis.CodeGen;
 using Microsoft.CodeAnalysis.CSharp.Emit;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
@@ -268,10 +270,24 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
 
             // Synthesized methods should have a sequence point
             // at offset 0 to ensure correct stepping behavior.
-            if (_emitPdbSequencePoints && _method.IsImplicitlyDeclared)
+            var emitInitialHiddenSequencePoint = false;
+            if (_emitPdbSequencePoints)
             {
-                _builder.DefineInitialHiddenSequencePoint();
+                if (_method.IsImplicitlyDeclared)
+                {
+                    emitInitialHiddenSequencePoint = true;
+                }
+                else if (_boundBody is BoundStatementList statementsList && statementsList.Statements.Length > 0)
+                {
+                    if (statementsList.Statements[0]?.Syntax.IsInlineStatement() == true)
+                    {
+                        // inline block statements don't have any '{...}' braces, so we need to add an initial hidden sequence point for those
+                        emitInitialHiddenSequencePoint = true;
+                    }
+                }
             }
+
+            if (emitInitialHiddenSequencePoint) _builder.DefineInitialHiddenSequencePoint();
 
             try
             {
@@ -318,7 +334,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 if (blockSyntax != null)
                 {
                     // some blocks may be "fake blocks" wrapping an "inline statement" ... we want to rebind those to the last "}" token of that inline statement
-                    if (blockSyntax.TryGetInlineStatement(out var inlineStatement))
+                    if (blockSyntax.TryGetInlineBlockStatement(out var inlineStatement))
                     {
                         var lastToken = inlineStatement.GetLastToken(includeZeroWidth: false, includeSkipped: false);
                         EmitSequencePoint(blockSyntax.SyntaxTree, lastToken.Span);

--- a/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/CodeGenerator.cs
@@ -317,7 +317,16 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGen
                 BlockSyntax blockSyntax = _methodBodySyntaxOpt as BlockSyntax;
                 if (blockSyntax != null)
                 {
-                    EmitSequencePoint(blockSyntax.SyntaxTree, blockSyntax.CloseBraceToken.Span);
+                    // some blocks may be "fake blocks" wrapping an "inline statement" ... we want to rebind those to the last "}" token of that inline statement
+                    if (blockSyntax.TryGetInlineStatement(out var inlineStatement))
+                    {
+                        var lastToken = inlineStatement.GetLastToken(includeZeroWidth: false, includeSkipped: false);
+                        EmitSequencePoint(blockSyntax.SyntaxTree, lastToken.Span);
+                    }
+                    else
+                    {
+                        EmitSequencePoint(blockSyntax.SyntaxTree, blockSyntax.CloseBraceToken.Span);
+                    }
                 }
             }
 

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -405,24 +405,24 @@ namespace Microsoft.CodeAnalysis.CSharp
             return (PropertySymbol)SpecialMember(sm);
         }
 
-        public BoundExpressionStatement Assignment(BoundExpression left, BoundExpression right, bool isRef = false)
+        public BoundExpressionStatement Assignment(BoundExpression left, BoundExpression right, bool isRef = false, SyntaxNode syntax = null)
         {
-            return ExpressionStatement(AssignmentExpression(left, right, isRef));
+            return ExpressionStatement(AssignmentExpression(left, right, isRef), syntax: syntax);
         }
 
-        public BoundExpressionStatement ExpressionStatement(BoundExpression expr)
+        public BoundExpressionStatement ExpressionStatement(BoundExpression expr, SyntaxNode syntax = null)
         {
-            return new BoundExpressionStatement(Syntax, expr) { WasCompilerGenerated = true };
+            return new BoundExpressionStatement(syntax ?? Syntax, expr) { WasCompilerGenerated = syntax == null };
         }
 
-        public BoundAssignmentOperator AssignmentExpression(BoundExpression left, BoundExpression right, bool isRef = false)
+        public BoundAssignmentOperator AssignmentExpression(BoundExpression left, BoundExpression right, bool isRef = false, SyntaxNode syntax = null)
         {
             Debug.Assert(left.Type is { } && right.Type is { } &&
                 (left.Type.Equals(right.Type, TypeCompareKind.AllIgnoreOptions) ||
                  StackOptimizerPass1.IsFixedBufferAssignmentToRefLocal(left, right, isRef) ||
                  right.Type.IsErrorType() || left.Type.IsErrorType()));
 
-            return new BoundAssignmentOperator(Syntax, left, right, left.Type, isRef: isRef) { WasCompilerGenerated = true };
+            return new BoundAssignmentOperator(syntax ?? Syntax, left, right, left.Type, isRef: isRef) { WasCompilerGenerated = syntax == null };
         }
 
         public BoundBlock Block()
@@ -839,9 +839,14 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new BoundThrowStatement(Syntax, e) { WasCompilerGenerated = true };
         }
 
-        public BoundLocal Local(LocalSymbol local)
+        public BoundLocalDeclaration LocalDeclaration(LocalSymbol localSymbol, BoundTypeExpression? declaredTypeOpt, BoundExpression? initializerOpt, ImmutableArray<BoundExpression> argumentsOpt, bool inferredType, bool hasErrors = false,SyntaxNode syntax = null)
         {
-            return new BoundLocal(Syntax, local, null, local.Type) { WasCompilerGenerated = true };
+            return new BoundLocalDeclaration(syntax ?? Syntax, localSymbol, declaredTypeOpt, initializerOpt, argumentsOpt, inferredType, hasErrors) { WasCompilerGenerated = true };
+        }
+
+        public BoundLocal Local(LocalSymbol local, SyntaxNode syntax = null)
+        {
+            return new BoundLocal(syntax ?? Syntax, local, null, local.Type) { WasCompilerGenerated = syntax == null };
         }
 
         public BoundExpression MakeSequence(LocalSymbol temp, params BoundExpression[] parts)

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -602,7 +602,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return AddTrailingSkippedSyntax(replacement, this.EatToken());
         }
 
-        private SyntaxToken CreateMissingToken(SyntaxKind expected, SyntaxKind actual, bool reportError)
+        protected SyntaxToken CreateMissingToken(SyntaxKind expected, SyntaxKind actual, bool reportError)
         {
             // should we eat the current ParseToken's leading trivia?
             var token = SyntaxFactory.MissingToken(expected);

--- a/src/Compilers/CSharp/Portable/Rewriters/LocalsRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/LocalsRewriter.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.Rewriters
+{
+    internal sealed class LocalsDictionary
+    {
+        private Dictionary<string, Entry> _locals;
+
+        internal LocalsDictionary()
+        {
+            _locals = new Dictionary<string, Entry>();
+        }
+
+        public int Count => _locals.Count;
+
+        public IEnumerable<LocalSymbol> GetLocalsByDeclOrder() => _locals.Values.OrderBy(e => e.DeclOrder).Select(e => e.Local);
+        public IEnumerable<(LocalSymbol, BoundLocalDeclaration)> GetLocalsWithDeclByDeclOrder() => _locals.Values.Where(e => e.Decl != null).OrderBy(e => e.DeclOrder).Select(e => (e.Local, e.Decl));
+
+        public bool TryGetLocal(string name, out LocalSymbol local)
+        {
+            local = null;
+            if (!_locals.TryGetValue(name, out var entry))
+                return false;
+
+            local = entry.Local;
+            return true;
+        }
+
+        public void SetLocal(string name, LocalSymbol local, BoundLocalDeclaration decl = null)
+        {
+            if (string.IsNullOrEmpty(name)) return;
+
+            if (_locals.TryGetValue(name, out var entry))
+            {
+                entry.Local = local;
+                if (decl != null) entry.Decl = decl;
+                return;
+            }
+
+            var declOrder = _locals.Values.Count;
+            _locals[name] = new Entry()
+            {
+                DeclOrder = declOrder,
+                Name = name,
+                Local = local,
+                Decl = decl
+            };
+        }
+
+        public bool TryGetDeclarataion(string name, out BoundLocalDeclaration decl)
+        {
+            decl = null;
+            if (!_locals.TryGetValue(name, out var entry))
+                return false;
+
+            decl = entry.Decl;
+            return true;
+        }
+
+        internal void SetLocalDeclaration(string name, BoundLocalDeclaration decl)
+        {
+            if (string.IsNullOrEmpty(name)) return;
+
+            if (_locals.TryGetValue(name, out var entry))
+            {
+                entry.Decl = decl;
+                return;
+            }
+
+            var declOrder = _locals.Values.Count;
+            _locals[name] = new Entry()
+            {
+                DeclOrder = declOrder,
+                Name = name,
+                Decl = decl
+            };
+        }
+
+        public void AppendLocals(IEnumerable<LocalSymbol> otherLocals)
+        {
+            foreach (var otherLocal in otherLocals)
+            {
+                SetLocal(otherLocal.Name, otherLocal);
+            }
+        }
+
+        class Entry
+        {
+            public int DeclOrder { get; set; }
+            public string Name { get; set; }
+            public LocalSymbol Local { get; set; }
+            public BoundLocalDeclaration Decl { get; set; }
+        }
+    }
+
+    internal sealed class LocalsRewriter : BoundTreeRewriterWithStackGuard
+    {
+        private LocalsDictionary _newLocals;
+
+        internal LocalsRewriter(LocalsDictionary newLocals)
+        {
+            _newLocals = newLocals;
+        }
+
+        public static BoundBlock RewriteBlockLocals(BoundBlock block, LocalsDictionary newLocals)
+        {
+            var newStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+            foreach (var stat in block.Statements)
+            {
+                // rewrite the locals in the statement
+                var newStatement = LocalsRewriter.RewriteLocals(stat, newLocals);
+                newStatements.Add(newStatement);
+            }
+
+            return block.Update(block.Locals, block.LocalFunctions, newStatements.ToImmutableArray());
+        }
+
+        public static TBoundNode RewriteLocals<TBoundNode>(TBoundNode node, LocalsDictionary newLocals)
+            where TBoundNode : BoundNode
+        {
+            if (node == null) return node;
+            var rewriter = new LocalsRewriter(newLocals);
+            return rewriter.Visit(node) as TBoundNode;
+        }
+
+        public override BoundNode VisitLocal(BoundLocal node)
+        {
+            var name = node.LocalSymbol.Name;
+            if (string.IsNullOrEmpty(name)) return node;
+
+            if (!_newLocals.TryGetLocal(name, out var newLocal)) return node;
+
+            return node.Update(newLocal, node.ConstantValueOpt, newLocal.Type);
+        }
+    }
+
+    internal sealed class LocalsFinder : BoundTreeWalkerWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+    {
+        private LocalsDictionary _locals;
+
+        private LocalsFinder(LocalsDictionary locals)
+        {
+            _locals = locals;
+        }
+
+        public static bool GetLocalsWithDeclarations(BoundBlock block, ref LocalsDictionary locals)
+        {
+            if (block?.Locals == null || block.Locals.Length == 0) return false;
+
+            locals = new LocalsDictionary();
+            FindLocals(block, locals);
+            return locals.Count > 0;
+        }
+
+        public static void FindLocals(BoundNode node, LocalsDictionary locals)
+        {
+            var finder = new LocalsFinder(locals);
+            finder.Visit(node);
+        }
+
+        public override BoundNode VisitLocalDeclaration(BoundLocalDeclaration node)
+        {
+            _locals.SetLocal(node.LocalSymbol?.Name, node.LocalSymbol, node);
+            return base.VisitLocalDeclaration(node);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Rewriters/MethodInlineTryCatchBlockRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/MethodInlineTryCatchBlockRewriter.cs
@@ -1,0 +1,175 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.Rewriters
+{
+    internal sealed class MethodInlineTryCatchBlockRewriter : BoundTreeRewriterWithStackGuardWithoutRecursionOnTheLeftOfBinaryOperator
+    {
+        private readonly SyntheticBoundNodeFactory _F;
+        private readonly DiagnosticBag _diagnostics;
+
+        private MethodInlineTryCatchBlockRewriter(
+            MethodSymbol containingMethod,
+            NamedTypeSymbol containingType,
+            SyntheticBoundNodeFactory factory,
+            DiagnosticBag diagnostics)
+        {
+            _F = factory;
+            _F.CurrentType = containingType;
+            _F.CurrentFunction = containingMethod;
+            _diagnostics = diagnostics;
+        }
+
+        public static BoundBlock Rewrite(
+            MethodSymbol containingSymbol,
+            NamedTypeSymbol containingType,
+            BoundBlock block,
+            TypeCompilationState compilationState,
+            DiagnosticBag diagnostics)
+        {
+            Debug.Assert(containingSymbol != null);
+            Debug.Assert((object)containingType != null);
+            Debug.Assert(block != null);
+            Debug.Assert(compilationState != null);
+            Debug.Assert(diagnostics != null);
+
+            var factory = new SyntheticBoundNodeFactory(containingSymbol, block.Syntax, compilationState, diagnostics);
+            var rewriter = new MethodInlineTryCatchBlockRewriter(containingSymbol, containingType, factory, diagnostics);
+            var newBlock = rewriter.Visit(block) as BoundBlock;
+            return newBlock;
+        }
+
+        public override BoundNode VisitBlock(BoundBlock node)
+        {
+            // only the first visited block can be the target of the rewrite - it's only allowed on method level!
+            if (node.Statements.Length != 1) return node;
+
+            // first statement must be another block
+            var statement = node.Statements[0] as BoundTryStatement;
+            if (statement == null) return node;
+
+            // handle special case of Method declaration with an appended catch / finally - it's always a wrapped try/catch with a missing "try" keyword
+            var tryStatementSyntax = statement.Syntax as Syntax.TryStatementSyntax;
+            if (tryStatementSyntax == null || !tryStatementSyntax.IsInlineBlockTryCatchStatement()) return node;
+
+            var methodDecl = tryStatementSyntax.Parent?.Parent as Syntax.MethodDeclarationSyntax;
+            if (methodDecl == null) return node;
+
+            // OK, we can rewrite the locals
+            return RewriteTryBlockLocals(statement, node);
+        }
+
+        private BoundNode RewriteTryBlockLocals(BoundTryStatement tryStatement, BoundBlock outerBlock)
+        {
+            // only if there are any locals in the try block
+            var tryBlock = tryStatement.TryBlock;
+
+            // get the locals - we only need to rewrite if there are actual local in the "try" block
+            LocalsDictionary locals = null;
+            if (!LocalsFinder.GetLocalsWithDeclarations(tryBlock, ref locals)) return outerBlock;
+
+            // the outer block may have it's own locals - those should be appended before
+            locals.AppendLocals(outerBlock.Locals);
+
+            // only if the locals are referenced from any of the catch/finally blocks
+
+            // build the new statements: try/catch statement + local declarations
+            var newOuterStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            //1. collect the locals in the "try block"
+            //2. create declarations statements that will be put into the outer block - so that they are accessible in both "catch" and "finally" blocks
+            //3. replace the locals declarations in the "try block" with "assignment statements" instea
+
+            // create declarations statements for each of the locals - and put into the outer block statements
+            var localsOuterDeclarationStatements = BuildLocalDeclStatements(locals);
+            newOuterStatements.AddRange(localsOuterDeclarationStatements);
+
+            // replace the old try block with the new try block
+            var newTryStatement = RewriteTryStatement(tryStatement, locals);
+            newOuterStatements.Add(newTryStatement);
+
+            // now build the new outer block
+            var newOuterBlock = outerBlock.Update(
+                locals: locals.GetLocalsByDeclOrder().ToImmutableArray(),
+                localFunctions: outerBlock.LocalFunctions,
+                statements: newOuterStatements.ToImmutable()
+            );
+            return newOuterBlock;
+        }
+
+        private ImmutableArray<BoundStatement> BuildLocalDeclStatements(LocalsDictionary locals)
+        {
+            var statements = ImmutableArray.CreateBuilder<BoundStatement>();
+            foreach (var l in locals.GetLocalsWithDeclByDeclOrder())
+            {
+                var local = l.Item1;
+                var decl = l.Item2;
+
+                var newLocalInitializer = _F.Default(local.Type);
+                var newLocalStatement = _F.LocalDeclaration(local, decl.DeclaredTypeOpt, newLocalInitializer, decl.ArgumentsOpt, decl.InferredType, decl.HasErrors, syntax: decl.Syntax);
+                statements.Add(newLocalStatement);
+            }
+            return statements.ToImmutable();
+        }
+
+        private BoundTryStatement RewriteTryStatement(BoundTryStatement tryStatement, LocalsDictionary newLocals)
+        {
+            // rewrite the try block
+            var newTryBlock = RewriteTryBlock(tryStatement.TryBlock, newLocals);
+
+            // now we have the new try statement
+            return tryStatement.Update(newTryBlock, tryStatement.CatchBlocks, tryStatement.FinallyBlockOpt, tryStatement.FinallyLabelOpt, tryStatement.PreferFaultHandler);
+        }
+
+        private BoundBlock RewriteTryBlock(BoundBlock tryBlock, LocalsDictionary newLocals)
+        {
+            // rewrite the statements in the try block
+            // 1. replace declarations of the locals with "assignments"
+            // 2. replace references to the locals with the new locals
+            var newTryStatements = ImmutableArray.CreateBuilder<BoundStatement>();
+
+            foreach (var stat in tryBlock.Statements)
+            {
+                if (stat is BoundLocalDeclaration localDecl)
+                {
+                    var local = localDecl.LocalSymbol;
+                    if (string.IsNullOrEmpty(local?.Name))
+                    {
+                        newTryStatements.Add(stat);
+                        continue;
+                    }
+
+                    // we need to use the new local when creating the assignment
+                    if (!newLocals.TryGetLocal(local.Name, out var newLocal))
+                    {
+                        newTryStatements.Add(stat);
+                        continue;
+                    }
+
+                    // if there is no initializer ... then we can just ignore the declaration
+                    if (localDecl.InitializerOpt == null)
+                    {
+                        continue;
+                    }
+
+                    // replace with an assignment instead of a declaration
+                    var assignLocal = _F.Local(newLocal, syntax: local?.DeclaringSyntaxReferences.FirstOrDefault()?.GetSyntax());
+                    var assignStatement = _F.Assignment(assignLocal, localDecl.InitializerOpt, syntax: localDecl.Syntax);
+                    newTryStatements.Add(assignStatement);
+                }
+                else
+                {
+                    // rewrite the locals in the statement
+                    newTryStatements.Add(stat);
+                }
+            }
+
+            // build the new try block - no locals should exist in it - and we should replace the statements with the new rewritten ones
+            return tryBlock.Update(ImmutableArray<LocalSymbol>.Empty, tryBlock.LocalFunctions, newTryStatements.ToImmutableArray());
+        }
+
+    }
+}

--- a/src/Compilers/CSharp/Portable/Rewriters/SyntaxRewritesPass.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/SyntaxRewritesPass.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.Rewriters
+{
+    internal class SyntaxRewritesPass
+    {
+        public static BoundBlock Rewrite(
+            MethodSymbol method,
+            BoundBlock block,
+            TypeCompilationState compilationState,
+            DiagnosticBag diagnostics,
+            bool hasTrailingExpression,
+            bool originalBodyNested)
+        {
+            block = MethodInlineTryCatchBlockRewriter.Rewrite(
+                        method,
+                        method.ContainingType,
+                        block,
+                        compilationState,
+                        diagnostics);
+
+            return block;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
@@ -13,15 +13,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         public BlockSyntax Update(SyntaxToken openBraceToken, SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
             => Update(attributeLists: default, openBraceToken, statements, closeBraceToken);
 
-        public bool IsInlineStatement()
+        public bool IsInlineBlockStatement()
         {
             return OpenBraceToken.Width == 0 && CloseBraceToken.Width == 0 && Statements.Count == 1;
         }
 
-        public bool TryGetInlineStatement(out StatementSyntax statement)
+        public bool TryGetInlineBlockStatement(out StatementSyntax statement)
         {
             statement = null;
-            if (!IsInlineStatement()) return false;
+            if (!IsInlineBlockStatement()) return false;
             statement = Statements[0];
             return true;
         }

--- a/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
@@ -12,6 +12,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     {
         public BlockSyntax Update(SyntaxToken openBraceToken, SyntaxList<StatementSyntax> statements, SyntaxToken closeBraceToken)
             => Update(attributeLists: default, openBraceToken, statements, closeBraceToken);
+
+        public bool IsInlineStatement()
+        {
+            return OpenBraceToken.Width == 0 && CloseBraceToken.Width == 0 && Statements.Count == 1;
+        }
+
+        public bool TryGetInlineStatement(out StatementSyntax statement)
+        {
+            statement = null;
+            if (!IsInlineStatement()) return false;
+            statement = Statements[0];
+            return true;
+        }
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -357,4 +357,48 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return SyntaxToken.GetWellKnownTokens();
         }
     }
+
+    internal static partial class SyntaxFactory
+    {
+        public static TryStatementSyntax FakeTryStatement(
+            ContextAwareSyntax syntaxFactory = null,
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists = default,
+            SyntaxToken tryToken = null,
+            BlockSyntax tryBlock = null,
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<CatchClauseSyntax> catchClauses = default,
+            SyntaxToken finallyToken = null,
+            BlockSyntax finallyBlock = null
+            )
+        {
+            tryToken ??= SyntaxFactory.FakeToken(SyntaxKind.TryKeyword, "try");
+
+            FinallyClauseSyntax finallyClause = null;
+            if (finallyBlock != null)
+            {
+                if (syntaxFactory != null)
+                    finallyClause = syntaxFactory.FinallyClause(finallyToken, finallyBlock);
+                else
+                    SyntaxFactory.FinallyClause(finallyToken, finallyBlock);
+            }
+
+            if (syntaxFactory != null)
+                return syntaxFactory.TryStatement(attributeLists: attributeLists, tryToken, tryBlock, catches: catchClauses, finallyClause);
+            else
+                return SyntaxFactory.TryStatement(attributeLists: attributeLists, tryToken, tryBlock, catches: catchClauses, finallyClause);
+        }
+
+        public static BlockSyntax FakeBlock(
+            ContextAwareSyntax syntaxFactory = null,
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists = default, 
+            SyntaxToken openBraceToken = null, 
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements = default, 
+            SyntaxToken closeBraceToken = null)
+        {
+            openBraceToken ??= SyntaxFactory.FakeToken(SyntaxKind.OpenBraceToken, "{");
+            closeBraceToken ??= SyntaxFactory.FakeToken(SyntaxKind.CloseBraceToken, "}");
+            if (syntaxFactory != null)
+                return syntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
+            return SyntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
+        }
+    }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxToken.cs
@@ -136,7 +136,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new FakeTokenWithTrivia(kind, value, allowTrivia);
         }
 
-        internal static SyntaxToken CreateMissing(SyntaxKind kind, GreenNode leading, GreenNode trailing)
+        internal static SyntaxToken CreateMissing(SyntaxKind kind, GreenNode leading = null, GreenNode trailing = null)
         {
             return new MissingTokenWithTrivia(kind, leading, trailing);
         }

--- a/src/Compilers/CSharp/Portable/Syntax/StatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/StatementSyntax.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax
+{
+    public static partial class StatementSyntaxNodeExtensions
+    {
+        public static bool IsInlineStatement(this SyntaxNode node)
+        {
+            if (node is TryStatementSyntax tryStatement)
+            {
+                return tryStatement.IsInlineBlockTryCatchStatement();
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
@@ -12,6 +12,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
     {
         public TryStatementSyntax Update(SyntaxToken tryKeyword, BlockSyntax block, SyntaxList<CatchClauseSyntax> catches, FinallyClauseSyntax @finally)
             => Update(attributeLists: default, tryKeyword, block, catches, @finally);
+
+        public bool IsInlineBlockTryCatchStatement()
+        {
+            return !TryKeyword.IsMissing && TryKeyword.Width == 0 && Parent is BlockSyntax;
+        }
     }
 }
 

--- a/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.cs
+++ b/src/Compilers/Core/Portable/Syntax/InternalSyntax/SyntaxList.cs
@@ -5,12 +5,21 @@
 #nullable enable
 
 using System.Diagnostics;
+using System.Dynamic;
 using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.Syntax.InternalSyntax
 {
     internal abstract partial class SyntaxList : GreenNode
     {
+        public static SyntaxList<T> Create<T>(params T[] nodes)
+            where T : GreenNode
+        {
+            var builder = SyntaxListBuilder<T>.Create();
+            foreach (var node in nodes) builder.Add(node);
+            return builder.ToList();
+        }
+
         internal SyntaxList()
             : base(GreenNode.ListKind)
         {

--- a/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.Result.cs
+++ b/src/Features/Core/Portable/ExtractMethod/AbstractSyntaxTriviaService.Result.cs
@@ -47,10 +47,17 @@ namespace Microsoft.CodeAnalysis.ExtractMethod
                 AnnotationResolver annotationResolver = null,
                 TriviaResolver triviaResolver = null)
             {
-                var tokens = RecoverTokensAtEdges(root, annotationResolver);
-                var map = CreateOldToNewTokensMap(tokens, triviaResolver);
+                try
+                {
+                    var tokens = RecoverTokensAtEdges(root, annotationResolver);
+                    var map = CreateOldToNewTokensMap(tokens, triviaResolver);
 
-                return root.ReplaceTokens(map.Keys, (o, n) => map[o]);
+                    return root.ReplaceTokens(map.Keys, (o, n) => map[o]);
+                }
+                catch (Exception)
+                {
+                    return root;
+                }
             }
 
             private static Dictionary<SyntaxToken, SyntaxToken> CreateOldToNewTokensMap(


### PR DESCRIPTION
Adds syntax simplification for writing method bodies with Try/Catch - allowing us to omit an additional nesting level - also changes the scope of variables declared inside the Try block, which can now be used in the Catch and Finally blocks as well.

Enables the following method declaration syntax:
```
MyMethod(arg string) {
  // method args and locals defined here are accessible both in the catch and finally blocks
  file := OpenFile()
  myValue := "testing"
} catch(e Exception) {
  Console.WriteLine($"Error in MyMethod - {myValue}") // note that we can access the "myValue" local
} finally {
  file?.Close()
  Console.WriteLine("Finished MyMethod execution - {myValue}") // note that we can access the "myValue" local
}
```