### PR TITLE
Feature/throw statement optional semicomma

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -10346,8 +10346,16 @@ tryAgain:
                 arg = this.ParseExpressionCore();
             }
 
-            var semi = this.EatToken(SyntaxKind.SemicolonToken);
-            return _syntaxFactory.ThrowStatement(attributes, @throw, arg, semi);
+            SyntaxToken semicolon = null;
+            if (CurrentToken.Kind == SyntaxKind.SemicolonToken)
+            {
+                semicolon = this.EatToken(SyntaxKind.SemicolonToken);
+            }
+            else if (IsProbablyStatementEnd())
+            {
+                semicolon = SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";");
+            }
+            return _syntaxFactory.ThrowStatement(attributes, @throw, arg, semicolon);
         }
 
         private UnsafeStatementSyntax ParseUnsafeStatement(SyntaxList<AttributeListSyntax> attributes)


### PR DESCRIPTION
Updates throw statements making the semicomma optional.

Enables the following syntax:

`throw new Exception("no semi comma") // no semicomma is needed`