### PR TITLE
Updates parsing of using directive - optional trailing semicomma

### DIFF
--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Commons.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Commons.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
+{
+    using System.Linq.Expressions;
+    using System.Text;
+    using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
+
+    internal partial class LanguageParser
+    {
+        private SyntaxToken TryParseEndOfLineSemicolon(
+            bool fakeAtStatementEnd = false,
+            bool fakeAtNewline = false,
+            bool optional = false
+            )
+        {
+            if (CurrentToken.Kind == SyntaxKind.SemicolonToken)
+            {
+                return this.EatToken(SyntaxKind.SemicolonToken);
+            }
+            else if(optional)
+            {
+                return SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";");
+            }
+            else if (fakeAtNewline && IsCurrentTokenOnNewline)
+            {
+                return SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";");
+            }
+            else if (fakeAtStatementEnd && IsProbablyStatementEnd())
+            {
+                return SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";");
+            }
+
+            // error: expected semicolon token
+            return this.EatToken(SyntaxKind.SemicolonToken);
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -318,6 +318,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
+        protected bool IsTokenOnNewline(SyntaxToken token, SyntaxToken prevToken)
+        {
+            if (token.LeadingTrivia.Any((int)SyntaxKind.EndOfLineTrivia)) return true;
+            if (prevToken != null && prevToken.TrailingTrivia.Any((int)SyntaxKind.EndOfLineTrivia)) return true;
+            return false;
+        }
+
         protected bool IsTokenAfterWhitespace(SyntaxToken token, SyntaxToken prevToken)
         {
             if (token.LeadingTrivia.Any((int)SyntaxKind.WhitespaceTrivia)) return true;


### PR DESCRIPTION
Updates syntax of using directives - making the trailing semicolon optional

Enables following syntax:

```
using System // no trailing comma needed
using System.Collections
```