### PR TITLE
Feature/import using directive

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -10,7 +10,7 @@ extern_alias_directive
   ;
 
 using_directive
-  : 'using' ('static' | name_equals)? name ';'
+  : import_keyword ('static' | name_equals)? name ';'
   ;
 
 name_equals
@@ -1284,6 +1284,10 @@ expression_or_pattern
   ;
 
 identifier_token
+  : /* see lexical specification */
+  ;
+
+import_keyword
   : /* see lexical specification */
   ;
 

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -19002,18 +19002,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal sealed partial class UsingDirectiveSyntax : CSharpSyntaxNode
     {
-        internal readonly SyntaxToken usingKeyword;
+        internal readonly SyntaxToken importKeyword;
         internal readonly SyntaxToken? staticKeyword;
         internal readonly NameEqualsSyntax? alias;
         internal readonly NameSyntax name;
         internal readonly SyntaxToken semicolonToken;
 
-        internal UsingDirectiveSyntax(SyntaxKind kind, SyntaxToken usingKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal UsingDirectiveSyntax(SyntaxKind kind, SyntaxToken importKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
             this.SlotCount = 5;
-            this.AdjustFlagsAndWidth(usingKeyword);
-            this.usingKeyword = usingKeyword;
+            this.AdjustFlagsAndWidth(importKeyword);
+            this.importKeyword = importKeyword;
             if (staticKeyword != null)
             {
                 this.AdjustFlagsAndWidth(staticKeyword);
@@ -19030,13 +19030,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             this.semicolonToken = semicolonToken;
         }
 
-        internal UsingDirectiveSyntax(SyntaxKind kind, SyntaxToken usingKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken, SyntaxFactoryContext context)
+        internal UsingDirectiveSyntax(SyntaxKind kind, SyntaxToken importKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
             this.SlotCount = 5;
-            this.AdjustFlagsAndWidth(usingKeyword);
-            this.usingKeyword = usingKeyword;
+            this.AdjustFlagsAndWidth(importKeyword);
+            this.importKeyword = importKeyword;
             if (staticKeyword != null)
             {
                 this.AdjustFlagsAndWidth(staticKeyword);
@@ -19053,12 +19053,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             this.semicolonToken = semicolonToken;
         }
 
-        internal UsingDirectiveSyntax(SyntaxKind kind, SyntaxToken usingKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
+        internal UsingDirectiveSyntax(SyntaxKind kind, SyntaxToken importKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
           : base(kind)
         {
             this.SlotCount = 5;
-            this.AdjustFlagsAndWidth(usingKeyword);
-            this.usingKeyword = usingKeyword;
+            this.AdjustFlagsAndWidth(importKeyword);
+            this.importKeyword = importKeyword;
             if (staticKeyword != null)
             {
                 this.AdjustFlagsAndWidth(staticKeyword);
@@ -19075,7 +19075,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             this.semicolonToken = semicolonToken;
         }
 
-        public SyntaxToken UsingKeyword => this.usingKeyword;
+        public SyntaxToken ImportKeyword => this.importKeyword;
         public SyntaxToken? StaticKeyword => this.staticKeyword;
         public NameEqualsSyntax? Alias => this.alias;
         public NameSyntax Name => this.name;
@@ -19084,7 +19084,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         internal override GreenNode? GetSlot(int index)
             => index switch
             {
-                0 => this.usingKeyword,
+                0 => this.importKeyword,
                 1 => this.staticKeyword,
                 2 => this.alias,
                 3 => this.name,
@@ -19097,11 +19097,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitUsingDirective(this);
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitUsingDirective(this);
 
-        public UsingDirectiveSyntax Update(SyntaxToken usingKeyword, SyntaxToken staticKeyword, NameEqualsSyntax alias, NameSyntax name, SyntaxToken semicolonToken)
+        public UsingDirectiveSyntax Update(SyntaxToken importKeyword, SyntaxToken staticKeyword, NameEqualsSyntax alias, NameSyntax name, SyntaxToken semicolonToken)
         {
-            if (usingKeyword != this.UsingKeyword || staticKeyword != this.StaticKeyword || alias != this.Alias || name != this.Name || semicolonToken != this.SemicolonToken)
+            if (importKeyword != this.ImportKeyword || staticKeyword != this.StaticKeyword || alias != this.Alias || name != this.Name || semicolonToken != this.SemicolonToken)
             {
-                var newNode = SyntaxFactory.UsingDirective(usingKeyword, staticKeyword, alias, name, semicolonToken);
+                var newNode = SyntaxFactory.UsingDirective(importKeyword, staticKeyword, alias, name, semicolonToken);
                 var diags = GetDiagnostics();
                 if (diags?.Length > 0)
                     newNode = newNode.WithDiagnosticsGreen(diags);
@@ -19115,18 +19115,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-            => new UsingDirectiveSyntax(this.Kind, this.usingKeyword, this.staticKeyword, this.alias, this.name, this.semicolonToken, diagnostics, GetAnnotations());
+            => new UsingDirectiveSyntax(this.Kind, this.importKeyword, this.staticKeyword, this.alias, this.name, this.semicolonToken, diagnostics, GetAnnotations());
 
         internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-            => new UsingDirectiveSyntax(this.Kind, this.usingKeyword, this.staticKeyword, this.alias, this.name, this.semicolonToken, GetDiagnostics(), annotations);
+            => new UsingDirectiveSyntax(this.Kind, this.importKeyword, this.staticKeyword, this.alias, this.name, this.semicolonToken, GetDiagnostics(), annotations);
 
         internal UsingDirectiveSyntax(ObjectReader reader)
           : base(reader)
         {
             this.SlotCount = 5;
-            var usingKeyword = (SyntaxToken)reader.ReadValue();
-            AdjustFlagsAndWidth(usingKeyword);
-            this.usingKeyword = usingKeyword;
+            var importKeyword = (SyntaxToken)reader.ReadValue();
+            AdjustFlagsAndWidth(importKeyword);
+            this.importKeyword = importKeyword;
             var staticKeyword = (SyntaxToken?)reader.ReadValue();
             if (staticKeyword != null)
             {
@@ -19150,7 +19150,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         internal override void WriteTo(ObjectWriter writer)
         {
             base.WriteTo(writer);
-            writer.WriteValue(this.usingKeyword);
+            writer.WriteValue(this.importKeyword);
             writer.WriteValue(this.staticKeyword);
             writer.WriteValue(this.alias);
             writer.WriteValue(this.name);
@@ -33644,7 +33644,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             => node.Update((SyntaxToken)Visit(node.ExternKeyword), (SyntaxToken)Visit(node.AliasKeyword), (SyntaxToken)Visit(node.Identifier), (SyntaxToken)Visit(node.SemicolonToken));
 
         public override CSharpSyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
-            => node.Update((SyntaxToken)Visit(node.UsingKeyword), (SyntaxToken)Visit(node.StaticKeyword), (NameEqualsSyntax)Visit(node.Alias), (NameSyntax)Visit(node.Name), (SyntaxToken)Visit(node.SemicolonToken));
+            => node.Update((SyntaxToken)Visit(node.ImportKeyword), (SyntaxToken)Visit(node.StaticKeyword), (NameEqualsSyntax)Visit(node.Alias), (NameSyntax)Visit(node.Name), (SyntaxToken)Visit(node.SemicolonToken));
 
         public override CSharpSyntaxNode VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
             => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), (SyntaxToken)Visit(node.NamespaceKeyword), (NameSyntax)Visit(node.Name), (SyntaxToken)Visit(node.PostNameSemicolonToken), (SyntaxToken)Visit(node.OpenBraceToken), VisitList(node.Externs), VisitList(node.Usings), VisitList(node.Members), (SyntaxToken)Visit(node.CloseBraceToken), (SyntaxToken)Visit(node.SemicolonToken));
@@ -36932,17 +36932,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new ExternAliasDirectiveSyntax(SyntaxKind.ExternAliasDirective, externKeyword, aliasKeyword, identifier, semicolonToken, this.context);
         }
 
-        public UsingDirectiveSyntax UsingDirective(SyntaxToken usingKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
+        public UsingDirectiveSyntax UsingDirective(SyntaxToken importKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
         {
 #if DEBUG
-            if (usingKeyword == null) throw new ArgumentNullException(nameof(usingKeyword));
-            if (usingKeyword.Kind != SyntaxKind.UsingKeyword) throw new ArgumentException(nameof(usingKeyword));
+            if (importKeyword == null) throw new ArgumentNullException(nameof(importKeyword));
+            if (importKeyword.Kind != SyntaxKind.ImportKeyword) throw new ArgumentException(nameof(importKeyword));
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (semicolonToken == null) throw new ArgumentNullException(nameof(semicolonToken));
             if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-            return new UsingDirectiveSyntax(SyntaxKind.UsingDirective, usingKeyword, staticKeyword, alias, name, semicolonToken, this.context);
+            return new UsingDirectiveSyntax(SyntaxKind.UsingDirective, importKeyword, staticKeyword, alias, name, semicolonToken, this.context);
         }
 
         public NamespaceDeclarationSyntax NamespaceDeclaration(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken namespaceKeyword, NameSyntax name, SyntaxToken? postNameSemicolonToken, SyntaxToken? openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<ExternAliasDirectiveSyntax> externs, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<UsingDirectiveSyntax> usings, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<MemberDeclarationSyntax> members, SyntaxToken? closeBraceToken, SyntaxToken? semicolonToken)
@@ -41779,17 +41779,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new ExternAliasDirectiveSyntax(SyntaxKind.ExternAliasDirective, externKeyword, aliasKeyword, identifier, semicolonToken);
         }
 
-        public static UsingDirectiveSyntax UsingDirective(SyntaxToken usingKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
+        public static UsingDirectiveSyntax UsingDirective(SyntaxToken importKeyword, SyntaxToken? staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
         {
 #if DEBUG
-            if (usingKeyword == null) throw new ArgumentNullException(nameof(usingKeyword));
-            if (usingKeyword.Kind != SyntaxKind.UsingKeyword) throw new ArgumentException(nameof(usingKeyword));
+            if (importKeyword == null) throw new ArgumentNullException(nameof(importKeyword));
+            if (importKeyword.Kind != SyntaxKind.ImportKeyword) throw new ArgumentException(nameof(importKeyword));
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (semicolonToken == null) throw new ArgumentNullException(nameof(semicolonToken));
             if (semicolonToken.Kind != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
 #endif
 
-            return new UsingDirectiveSyntax(SyntaxKind.UsingDirective, usingKeyword, staticKeyword, alias, name, semicolonToken);
+            return new UsingDirectiveSyntax(SyntaxKind.UsingDirective, importKeyword, staticKeyword, alias, name, semicolonToken);
         }
 
         public static NamespaceDeclarationSyntax NamespaceDeclaration(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken namespaceKeyword, NameSyntax name, SyntaxToken? postNameSemicolonToken, SyntaxToken? openBraceToken, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<ExternAliasDirectiveSyntax> externs, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<UsingDirectiveSyntax> usings, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<MemberDeclarationSyntax> members, SyntaxToken? closeBraceToken, SyntaxToken? semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -2034,7 +2034,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => node.Update(VisitToken(node.ExternKeyword), VisitToken(node.AliasKeyword), VisitToken(node.Identifier), VisitToken(node.SemicolonToken));
 
         public override SyntaxNode? VisitUsingDirective(UsingDirectiveSyntax node)
-            => node.Update(VisitToken(node.UsingKeyword), VisitToken(node.StaticKeyword), (NameEqualsSyntax?)Visit(node.Alias), (NameSyntax?)Visit(node.Name) ?? throw new ArgumentNullException("name"), VisitToken(node.SemicolonToken));
+            => node.Update(VisitToken(node.ImportKeyword), VisitToken(node.StaticKeyword), (NameEqualsSyntax?)Visit(node.Alias), (NameSyntax?)Visit(node.Name) ?? throw new ArgumentNullException("name"), VisitToken(node.SemicolonToken));
 
         public override SyntaxNode? VisitNamespaceDeclaration(NamespaceDeclarationSyntax node)
             => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), VisitToken(node.NamespaceKeyword), (NameSyntax?)Visit(node.Name) ?? throw new ArgumentNullException("name"), VisitToken(node.PostNameSemicolonToken), VisitToken(node.OpenBraceToken), VisitList(node.Externs), VisitList(node.Usings), VisitList(node.Members), VisitToken(node.CloseBraceToken), VisitToken(node.SemicolonToken));
@@ -4746,21 +4746,21 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SyntaxFactory.ExternAliasDirective(SyntaxFactory.Token(SyntaxKind.ExternKeyword), SyntaxFactory.Token(SyntaxKind.AliasKeyword), SyntaxFactory.Identifier(identifier), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
-        public static UsingDirectiveSyntax UsingDirective(SyntaxToken usingKeyword, SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
+        public static UsingDirectiveSyntax UsingDirective(SyntaxToken importKeyword, SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
         {
-            if (usingKeyword.Kind() != SyntaxKind.UsingKeyword) throw new ArgumentException(nameof(usingKeyword));
+            if (importKeyword.Kind() != SyntaxKind.ImportKeyword) throw new ArgumentException(nameof(importKeyword));
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (semicolonToken.Kind() != SyntaxKind.SemicolonToken) throw new ArgumentException(nameof(semicolonToken));
-            return (UsingDirectiveSyntax)Syntax.InternalSyntax.SyntaxFactory.UsingDirective((Syntax.InternalSyntax.SyntaxToken)usingKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken?)staticKeyword.Node, alias == null ? null : (Syntax.InternalSyntax.NameEqualsSyntax)alias.Green, (Syntax.InternalSyntax.NameSyntax)name.Green, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
+            return (UsingDirectiveSyntax)Syntax.InternalSyntax.SyntaxFactory.UsingDirective((Syntax.InternalSyntax.SyntaxToken)importKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken?)staticKeyword.Node, alias == null ? null : (Syntax.InternalSyntax.NameEqualsSyntax)alias.Green, (Syntax.InternalSyntax.NameSyntax)name.Green, (Syntax.InternalSyntax.SyntaxToken)semicolonToken.Node!).CreateRed();
         }
 
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
         public static UsingDirectiveSyntax UsingDirective(SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name)
-            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.UsingKeyword), staticKeyword, alias, name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.ImportKeyword), staticKeyword, alias, name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
         public static UsingDirectiveSyntax UsingDirective(NameSyntax name)
-            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.UsingKeyword), default, default, name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.ImportKeyword), default, default, name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         /// <summary>Creates a new NamespaceDeclarationSyntax instance.</summary>
         public static NamespaceDeclarationSyntax NamespaceDeclaration(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken namespaceKeyword, NameSyntax name, SyntaxToken postNameSemicolonToken, SyntaxToken openBraceToken, SyntaxList<ExternAliasDirectiveSyntax> externs, SyntaxList<UsingDirectiveSyntax> usings, SyntaxList<MemberDeclarationSyntax> members, SyntaxToken closeBraceToken, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -4739,11 +4739,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>Creates a new ExternAliasDirectiveSyntax instance.</summary>
         public static ExternAliasDirectiveSyntax ExternAliasDirective(SyntaxToken identifier)
-            => SyntaxFactory.ExternAliasDirective(SyntaxFactory.Token(SyntaxKind.ExternKeyword), SyntaxFactory.Token(SyntaxKind.AliasKeyword), identifier, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.ExternAliasDirective(SyntaxFactory.Token(SyntaxKind.ExternKeyword), SyntaxFactory.Token(SyntaxKind.AliasKeyword), identifier, SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";"));
 
         /// <summary>Creates a new ExternAliasDirectiveSyntax instance.</summary>
         public static ExternAliasDirectiveSyntax ExternAliasDirective(string identifier)
-            => SyntaxFactory.ExternAliasDirective(SyntaxFactory.Token(SyntaxKind.ExternKeyword), SyntaxFactory.Token(SyntaxKind.AliasKeyword), SyntaxFactory.Identifier(identifier), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.ExternAliasDirective(SyntaxFactory.Token(SyntaxKind.ExternKeyword), SyntaxFactory.Token(SyntaxKind.AliasKeyword), SyntaxFactory.Identifier(identifier), SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";"));
 
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
         public static UsingDirectiveSyntax UsingDirective(SyntaxToken importKeyword, SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
@@ -4756,11 +4756,11 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
         public static UsingDirectiveSyntax UsingDirective(SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name)
-            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.ImportKeyword), staticKeyword, alias, name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.ImportKeyword), staticKeyword, alias, name, SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";"));
 
         /// <summary>Creates a new UsingDirectiveSyntax instance.</summary>
         public static UsingDirectiveSyntax UsingDirective(NameSyntax name)
-            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.ImportKeyword), default, default, name, SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.ImportKeyword), default, default, name, SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken, ";"));
 
         /// <summary>Creates a new NamespaceDeclarationSyntax instance.</summary>
         public static NamespaceDeclarationSyntax NamespaceDeclaration(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken namespaceKeyword, NameSyntax name, SyntaxToken postNameSemicolonToken, SyntaxToken openBraceToken, SyntaxList<ExternAliasDirectiveSyntax> externs, SyntaxList<UsingDirectiveSyntax> usings, SyntaxList<MemberDeclarationSyntax> members, SyntaxToken closeBraceToken, SyntaxToken semicolonToken)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -8124,7 +8124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
         }
 
-        public SyntaxToken UsingKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.UsingDirectiveSyntax)this.Green).usingKeyword, Position, 0);
+        public SyntaxToken ImportKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.UsingDirectiveSyntax)this.Green).importKeyword, Position, 0);
 
         public SyntaxToken StaticKeyword
         {
@@ -8161,11 +8161,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         [return: MaybeNull]
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitUsingDirective(this);
 
-        public UsingDirectiveSyntax Update(SyntaxToken usingKeyword, SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
+        public UsingDirectiveSyntax Update(SyntaxToken importKeyword, SyntaxToken staticKeyword, NameEqualsSyntax? alias, NameSyntax name, SyntaxToken semicolonToken)
         {
-            if (usingKeyword != this.UsingKeyword || staticKeyword != this.StaticKeyword || alias != this.Alias || name != this.Name || semicolonToken != this.SemicolonToken)
+            if (importKeyword != this.ImportKeyword || staticKeyword != this.StaticKeyword || alias != this.Alias || name != this.Name || semicolonToken != this.SemicolonToken)
             {
-                var newNode = SyntaxFactory.UsingDirective(usingKeyword, staticKeyword, alias, name, semicolonToken);
+                var newNode = SyntaxFactory.UsingDirective(importKeyword, staticKeyword, alias, name, semicolonToken);
                 var annotations = GetAnnotations();
                 return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
             }
@@ -8173,11 +8173,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return this;
         }
 
-        public UsingDirectiveSyntax WithUsingKeyword(SyntaxToken usingKeyword) => Update(usingKeyword, this.StaticKeyword, this.Alias, this.Name, this.SemicolonToken);
-        public UsingDirectiveSyntax WithStaticKeyword(SyntaxToken staticKeyword) => Update(this.UsingKeyword, staticKeyword, this.Alias, this.Name, this.SemicolonToken);
-        public UsingDirectiveSyntax WithAlias(NameEqualsSyntax? alias) => Update(this.UsingKeyword, this.StaticKeyword, alias, this.Name, this.SemicolonToken);
-        public UsingDirectiveSyntax WithName(NameSyntax name) => Update(this.UsingKeyword, this.StaticKeyword, this.Alias, name, this.SemicolonToken);
-        public UsingDirectiveSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.UsingKeyword, this.StaticKeyword, this.Alias, this.Name, semicolonToken);
+        public UsingDirectiveSyntax WithImportKeyword(SyntaxToken importKeyword) => Update(importKeyword, this.StaticKeyword, this.Alias, this.Name, this.SemicolonToken);
+        public UsingDirectiveSyntax WithStaticKeyword(SyntaxToken staticKeyword) => Update(this.ImportKeyword, staticKeyword, this.Alias, this.Name, this.SemicolonToken);
+        public UsingDirectiveSyntax WithAlias(NameEqualsSyntax? alias) => Update(this.ImportKeyword, this.StaticKeyword, alias, this.Name, this.SemicolonToken);
+        public UsingDirectiveSyntax WithName(NameSyntax name) => Update(this.ImportKeyword, this.StaticKeyword, this.Alias, name, this.SemicolonToken);
+        public UsingDirectiveSyntax WithSemicolonToken(SyntaxToken semicolonToken) => Update(this.ImportKeyword, this.StaticKeyword, this.Alias, this.Name, semicolonToken);
     }
 
     /// <summary>Member declaration syntax.</summary>

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -529,7 +529,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                                 break;
                             }
 
-                        case SyntaxKind.UsingKeyword:
+                        case SyntaxKind.ImportKeyword:
                             if (isGlobal && (this.PeekToken(1).Kind == SyntaxKind.OpenParenToken || (!IsScript && IsPossibleTopLevelUsingLocalDeclarationStatement())))
                             {
                                 // Top-level using statement or using local declaration
@@ -707,7 +707,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             switch (this.CurrentToken.Kind)
             {
                 case SyntaxKind.ExternKeyword:
-                case SyntaxKind.UsingKeyword:
+                case SyntaxKind.ImportKeyword:
                 case SyntaxKind.NamespaceKeyword:
                     return true;
                 case SyntaxKind.IdentifierToken:
@@ -802,9 +802,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 return (UsingDirectiveSyntax)this.EatNode();
             }
 
-            Debug.Assert(this.CurrentToken.Kind == SyntaxKind.UsingKeyword);
+            Debug.Assert(this.CurrentToken.Kind == SyntaxKind.ImportKeyword);
 
-            var usingToken = this.EatToken(SyntaxKind.UsingKeyword);
+            var importToken = this.EatToken(SyntaxKind.ImportKeyword);
             var staticToken = this.TryEatToken(SyntaxKind.StaticKeyword);
 
             var alias = this.IsNamedAssignment() ? ParseNameEquals() : null;
@@ -844,7 +844,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
             var semicolon = TryParseEndOfLineSemicolon(optional: true);
 
-            var usingDirective = _syntaxFactory.UsingDirective(usingToken, staticToken, alias, name, semicolon);
+            var usingDirective = _syntaxFactory.UsingDirective(importToken, staticToken, alias, name, semicolon);
             if (staticToken != null)
             {
                 usingDirective = CheckFeatureAvailability(usingDirective, MessageID.IDS_FeatureUsingStatic);

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -52,6 +52,7 @@ Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax.WithType(Microsoft
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.ColonEqualsToken = 8223 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.DefaultConstraint = 9057 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.FnKeyword = 8445 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.ImportKeyword = 8385 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LambdaFunctionType = 9034 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.Modifiers.get -> Microsoft.CodeAnalysis.SyntaxTokenList
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.CommonForEachStatementSyntax.EqualsGreaterThanToken.get -> Microsoft.CodeAnalysis.SyntaxToken

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -2985,8 +2985,8 @@
   </Node>
   <Node Name="UsingDirectiveSyntax" Base="CSharpSyntaxNode">
     <Kind Name="UsingDirective"/>
-    <Field Name="UsingKeyword" Type="SyntaxToken">
-      <Kind Name="UsingKeyword"/>
+    <Field Name="ImportKeyword" Type="SyntaxToken">
+      <Kind Name="ImportKeyword"/>
     </Field>
     <Choice Optional="true">
       <Field Name="StaticKeyword" Type="SyntaxToken"/>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxFactory.cs
@@ -2509,7 +2509,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static UsingDirectiveSyntax UsingDirective(NameEqualsSyntax alias, NameSyntax name)
         {
             return UsingDirective(
-                usingKeyword: Token(SyntaxKind.UsingKeyword),
+                importKeyword: Token(SyntaxKind.ImportKeyword),
                 staticKeyword: default(SyntaxToken),
                 alias: alias,
                 name: name,

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -164,6 +164,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         OperatorKeyword = 8382,
         ExplicitKeyword = 8383,
         ImplicitKeyword = 8384,
+        ImportKeyword = 8385,
 
         // contextual keywords
         YieldKeyword = 8405,

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -39,7 +39,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         public static bool IsReservedKeyword(SyntaxKind kind)
         {
-            return kind >= SyntaxKind.BoolKeyword && kind <= SyntaxKind.ImplicitKeyword;
+            return kind >= SyntaxKind.BoolKeyword && kind <= SyntaxKind.ImportKeyword;
         }
 
         public static bool IsAttributeTargetSpecifier(SyntaxKind kind)
@@ -965,6 +965,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return SyntaxKind.NamespaceKeyword;
                 case "using":
                     return SyntaxKind.UsingKeyword;
+                case "import":
+                    return SyntaxKind.ImportKeyword;
                 case "class":
                     return SyntaxKind.ClassKeyword;
                 case "struct":
@@ -1545,6 +1547,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return "namespace";
                 case SyntaxKind.UsingKeyword:
                     return "using";
+                case SyntaxKind.ImportKeyword:
+                    return "import";
                 case SyntaxKind.ClassKeyword:
                     return "class";
                 case SyntaxKind.StructKeyword:

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -434,7 +434,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.ExternAliasDirective(InternalSyntaxFactory.Token(SyntaxKind.ExternKeyword), InternalSyntaxFactory.Token(SyntaxKind.AliasKeyword), InternalSyntaxFactory.Identifier("Identifier"), InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.UsingDirectiveSyntax GenerateUsingDirective()
-            => InternalSyntaxFactory.UsingDirective(InternalSyntaxFactory.Token(SyntaxKind.UsingKeyword), null, null, GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => InternalSyntaxFactory.UsingDirective(InternalSyntaxFactory.Token(SyntaxKind.ImportKeyword), null, null, GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static Syntax.InternalSyntax.NamespaceDeclarationSyntax GenerateNamespaceDeclaration()
             => InternalSyntaxFactory.NamespaceDeclaration(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.SyntaxToken>(), InternalSyntaxFactory.Token(SyntaxKind.NamespaceKeyword), GenerateIdentifierName(), null, null, new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.ExternAliasDirectiveSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.UsingDirectiveSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.MemberDeclarationSyntax>(), null, null);
@@ -2448,7 +2448,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateUsingDirective();
 
-            Assert.Equal(SyntaxKind.UsingKeyword, node.UsingKeyword.Kind);
+            Assert.Equal(SyntaxKind.ImportKeyword, node.ImportKeyword.Kind);
             Assert.Null(node.StaticKeyword);
             Assert.Null(node.Alias);
             Assert.NotNull(node.Name);
@@ -9945,7 +9945,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.ExternAliasDirective(SyntaxFactory.Token(SyntaxKind.ExternKeyword), SyntaxFactory.Token(SyntaxKind.AliasKeyword), SyntaxFactory.Identifier("Identifier"), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static UsingDirectiveSyntax GenerateUsingDirective()
-            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.UsingKeyword), default(SyntaxToken), default(NameEqualsSyntax), GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+            => SyntaxFactory.UsingDirective(SyntaxFactory.Token(SyntaxKind.ImportKeyword), default(SyntaxToken), default(NameEqualsSyntax), GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.SemicolonToken));
 
         private static NamespaceDeclarationSyntax GenerateNamespaceDeclaration()
             => SyntaxFactory.NamespaceDeclaration(new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), SyntaxFactory.Token(SyntaxKind.NamespaceKeyword), GenerateIdentifierName(), default(SyntaxToken), default(SyntaxToken), new SyntaxList<ExternAliasDirectiveSyntax>(), new SyntaxList<UsingDirectiveSyntax>(), new SyntaxList<MemberDeclarationSyntax>(), default(SyntaxToken), default(SyntaxToken));
@@ -11959,12 +11959,12 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateUsingDirective();
 
-            Assert.Equal(SyntaxKind.UsingKeyword, node.UsingKeyword.Kind());
+            Assert.Equal(SyntaxKind.ImportKeyword, node.ImportKeyword.Kind());
             Assert.Equal(SyntaxKind.None, node.StaticKeyword.Kind());
             Assert.Null(node.Alias);
             Assert.NotNull(node.Name);
             Assert.Equal(SyntaxKind.SemicolonToken, node.SemicolonToken.Kind());
-            var newNode = node.WithUsingKeyword(node.UsingKeyword).WithStaticKeyword(node.StaticKeyword).WithAlias(node.Alias).WithName(node.Name).WithSemicolonToken(node.SemicolonToken);
+            var newNode = node.WithImportKeyword(node.ImportKeyword).WithStaticKeyword(node.StaticKeyword).WithAlias(node.Alias).WithName(node.Name).WithSemicolonToken(node.SemicolonToken);
             Assert.Equal(node, newNode);
         }
 

--- a/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Parsing/DeclarationParsingTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsing()
         {
-            var text = "using a;";
+            var text = "import a;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -60,8 +60,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotEqual(default, ud.UsingKeyword);
-            Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
+            Assert.NotEqual(default, ud.ImportKeyword);
+            Assert.Equal(SyntaxKind.UsingKeyword, ud.ImportKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.True(ud.StaticKeyword == default(SyntaxToken));
             Assert.NotNull(ud.Name);
@@ -72,7 +72,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingStatic()
         {
-            var text = "using static a;";
+            var text = "import static a;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -82,8 +82,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotEqual(default, ud.UsingKeyword);
-            Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
+            Assert.NotEqual(default, ud.ImportKeyword);
+            Assert.Equal(SyntaxKind.UsingKeyword, ud.ImportKeyword.Kind());
             Assert.Equal(SyntaxKind.StaticKeyword, ud.StaticKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
@@ -94,7 +94,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingStaticInWrongOrder()
         {
-            var text = "static using a;";
+            var text = "import using a;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -109,7 +109,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestDuplicateStatic()
         {
-            var text = "using static static a;";
+            var text = "import static static a;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -124,7 +124,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingNamespace()
         {
-            var text = "using namespace a;";
+            var text = "import namespace a;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -139,7 +139,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingDottedName()
         {
-            var text = "using a.b;";
+            var text = "import a.b;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -149,8 +149,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotEqual(default, ud.UsingKeyword);
-            Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
+            Assert.NotEqual(default, ud.ImportKeyword);
+            Assert.Equal(SyntaxKind.UsingKeyword, ud.ImportKeyword.Kind());
             Assert.True(ud.StaticKeyword == default(SyntaxToken));
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
@@ -161,7 +161,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingStaticDottedName()
         {
-            var text = "using static a.b;";
+            var text = "import static a.b;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -171,8 +171,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotEqual(default, ud.UsingKeyword);
-            Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
+            Assert.NotEqual(default, ud.ImportKeyword);
+            Assert.Equal(SyntaxKind.UsingKeyword, ud.ImportKeyword.Kind());
             Assert.Equal(SyntaxKind.StaticKeyword, ud.StaticKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
@@ -183,7 +183,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingStaticGenericName()
         {
-            var text = "using static a<int?>;";
+            var text = "import static a<int?>;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -193,8 +193,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotEqual(default, ud.UsingKeyword);
-            Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
+            Assert.NotEqual(default, ud.ImportKeyword);
+            Assert.Equal(SyntaxKind.UsingKeyword, ud.ImportKeyword.Kind());
             Assert.Equal(SyntaxKind.StaticKeyword, ud.StaticKeyword.Kind());
             Assert.Null(ud.Alias);
             Assert.NotNull(ud.Name);
@@ -205,7 +205,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingAliasName()
         {
-            var text = "using a = b;";
+            var text = "import a = b;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -215,8 +215,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotEqual(default, ud.UsingKeyword);
-            Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
+            Assert.NotEqual(default, ud.ImportKeyword);
+            Assert.Equal(SyntaxKind.UsingKeyword, ud.ImportKeyword.Kind());
             Assert.NotNull(ud.Alias);
             Assert.NotNull(ud.Alias.Name);
             Assert.Equal("a", ud.Alias.Name.ToString());
@@ -229,7 +229,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         [Fact]
         public void TestUsingAliasGenericName()
         {
-            var text = "using a = b<c>;";
+            var text = "import a = b<c>;";
             var file = this.ParseFile(text);
 
             Assert.NotNull(file);
@@ -239,8 +239,8 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             var ud = file.Usings[0];
 
-            Assert.NotEqual(default, ud.UsingKeyword);
-            Assert.Equal(SyntaxKind.UsingKeyword, ud.UsingKeyword.Kind());
+            Assert.NotEqual(default, ud.ImportKeyword);
+            Assert.Equal(SyntaxKind.UsingKeyword, ud.ImportKeyword.Kind());
             Assert.NotNull(ud.Alias);
             Assert.NotNull(ud.Alias.Name);
             Assert.Equal("a", ud.Alias.Name.ToString());

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -14,6 +14,7 @@ Microsoft.CodeAnalysis.SyntaxNode.HasErrors.get -> bool
 Microsoft.CodeAnalysis.SyntaxNodeOrToken.FullSpanInternal.get -> Microsoft.CodeAnalysis.Text.TextSpan
 Microsoft.CodeAnalysis.SyntaxToken.FindNextToken(System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
 Microsoft.CodeAnalysis.SyntaxToken.FindPreviousToken(System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
+Microsoft.CodeAnalysis.SyntaxToken.GetFirstTokenOnLine(bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.SyntaxTreeOptionsProvider() -> void
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.IsGenerated(Microsoft.CodeAnalysis.SyntaxTree tree) -> bool?

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -627,36 +627,6 @@ namespace Microsoft.CodeAnalysis
             return SyntaxNavigator.Instance.GetPreviousToken(this, includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
         }
 
-        public SyntaxToken? FindPreviousToken(Func<SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false)
-        {
-            if (Node == null)
-                return null;
-
-            var token = this;
-            while (token.Node != null)
-            {
-                if (predicate(token)) return token;
-                token = token.GetPreviousToken(includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
-            }
-
-            return null;
-        }
-
-        public SyntaxToken? FindNextToken(Func<SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false)
-        {
-            if (Node == null)
-                return null;
-
-            var token = this;
-            while (token.Node != null)
-            {
-                if (predicate(token)) return token;
-                token = token.GetNextToken(includeZeroWidth, includeSkipped, includeDirectives, includeDocumentationComments);
-            }
-
-            return null;
-        }
-
         /// <summary>
         /// Returns the token before this token in the syntax tree.
         /// </summary>

--- a/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
+++ b/src/Features/CSharp/Portable/AddImport/CSharpAddImportFeatureService.cs
@@ -281,7 +281,7 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         }
 
         protected override string GetDescription(IReadOnlyList<string> nameParts)
-            => $"using { string.Join(".", nameParts) };";
+            => $"import { string.Join(".", nameParts) }";
 
         protected override (string description, bool hasExistingImport) GetDescription(
             Document document,
@@ -328,8 +328,8 @@ namespace Microsoft.CodeAnalysis.CSharp.AddImport
         {
             var displayString = namespaceOrTypeSymbol.ToDisplayString();
             return namespaceOrTypeSymbol.IsKind(SymbolKind.Namespace)
-                ? $"using {displayString};"
-                : $"using static {displayString};";
+                ? $"import {displayString}"
+                : $"import static {displayString}";
         }
 
         protected override async Task<Document> AddImportAsync(

--- a/src/Features/CSharp/Portable/AliasAmbiguousType/CSharpAliasAmbiguousTypeCodeFixProvider.cs
+++ b/src/Features/CSharp/Portable/AliasAmbiguousType/CSharpAliasAmbiguousTypeCodeFixProvider.cs
@@ -30,6 +30,6 @@ namespace Microsoft.CodeAnalysis.CSharp.AliasAmbiguousType
             => ImmutableArray.Create(CS0104);
 
         protected override string GetTextPreviewOfChange(string alias, ITypeSymbol typeSymbol)
-            => $"using { alias } = { typeSymbol.ToNameDisplayString() };";
+            => $"import { alias } = { typeSymbol.ToNameDisplayString() }";
     }
 }

--- a/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UsingKeywordRecommender.cs
+++ b/src/Features/CSharp/Portable/Completion/KeywordRecommenders/UsingKeywordRecommender.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Completion.KeywordRecommenders
     internal class UsingKeywordRecommender : AbstractSyntacticSingleKeywordRecommender
     {
         public UsingKeywordRecommender()
-            : base(SyntaxKind.UsingKeyword)
+            : base(SyntaxKind.ImportKeyword)
         {
         }
 

--- a/src/VisualStudio/CSharp/Impl/Options/Formatting/NewLinesViewModel.cs
+++ b/src/VisualStudio/CSharp/Impl/Options/Formatting/NewLinesViewModel.cs
@@ -46,7 +46,7 @@ class C {
 //]
 }";
 
-        private const string s_tryCatchFinallyPreview = @"using System;
+        private const string s_tryCatchFinallyPreview = @"import System
 class C {
     void Goo() {
 //[
@@ -80,7 +80,7 @@ class C {
     }
 }";
 
-        private const string s_lambdaPreview = @"using System;
+        private const string s_lambdaPreview = @"import System
 class C {
     void Goo() {
 //[
@@ -90,7 +90,7 @@ class C {
 //]
     }
 }";
-        private const string s_anonymousMethodPreview = @"using System;
+        private const string s_anonymousMethodPreview = @"import System
 
 delegate int D(int x);
 
@@ -104,7 +104,7 @@ class C {
     }
 }";
 
-        private const string s_anonymousTypePreview = @"using System;
+        private const string s_anonymousTypePreview = @"import System
 class C {
     void Goo() {
 //[
@@ -114,8 +114,8 @@ class C {
 //]
     }
 }";
-        private const string s_InitializerPreviewTrue = @"using System;
-using System.Collections.Generic;
+        private const string s_InitializerPreviewTrue = @"import System
+import System.Collections.Generic
 
 class C {
     void Goo() {
@@ -142,8 +142,8 @@ class B {
     public int A { get; set; }
     public int B { get; set; }
 }";
-        private const string s_InitializerPreviewFalse = @"using System;
-using System.Collections.Generic;
+        private const string s_InitializerPreviewFalse = @"import System
+import System.Collections.Generic
 
 class C {
     void Goo() {
@@ -167,7 +167,7 @@ class B {
     public int A { get; set; }
     public int B { get; set; }
 }";
-        private const string s_objectInitializerPreview = @"using System;
+        private const string s_objectInitializerPreview = @"import System
 class C {
     void Goo() {
 //[
@@ -182,9 +182,9 @@ class B {
     public int A { get; set; }
     public int B { get; set; }
 }";
-        private const string s_queryExpressionPreview = @"using System;
-using System.Linq;
-using System.Collections.Generic;
+        private const string s_queryExpressionPreview = @"import System
+import System.Linq
+import System.Collections.Generic
 class C {
     void Goo(IEnumerable<int> e) {
 //[

--- a/src/VisualStudio/CSharp/Impl/Snippets/SnippetExpansionClient.cs
+++ b/src/VisualStudio/CSharp/Impl/Snippets/SnippetExpansionClient.cs
@@ -146,7 +146,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
                     continue;
                 }
 
-                var candidateUsing = SyntaxFactory.ParseCompilationUnit("using " + namespaceToImport + ";").DescendantNodes().OfType<UsingDirectiveSyntax>().FirstOrDefault();
+                var candidateUsing = SyntaxFactory.ParseCompilationUnit("import " + namespaceToImport).DescendantNodes().OfType<UsingDirectiveSyntax>().FirstOrDefault();
                 if (candidateUsing == null)
                 {
                     continue;
@@ -155,7 +155,7 @@ namespace Microsoft.VisualStudio.LanguageServices.CSharp.Snippets
                 {
                     // Retry by parsing the namespace as a name and constructing a using directive from it
                     candidateUsing = SyntaxFactory.UsingDirective(SyntaxFactory.ParseName(namespaceToImport))
-                        .WithUsingKeyword(SyntaxFactory.Token(SyntaxKind.UsingKeyword).WithTrailingTrivia(SyntaxFactory.Space));
+                        .WithImportKeyword(SyntaxFactory.Token(SyntaxKind.ImportKeyword).WithTrailingTrivia(SyntaxFactory.Space));
                 }
 
                 if (!existingUsings.Any(u => u.IsEquivalentTo(candidateUsing, topLevel: false)))

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CSharpCompilerExtensions.projitems
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/CSharpCompilerExtensions.projitems
@@ -70,6 +70,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\FormattingHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\Rules\AnchorIndentationFormattingRule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\Rules\BaseFormattingRule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Formatting\Rules\CSharpNewlineFormattingRule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\Rules\ElasticTriviaFormattingRule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\Rules\EndOfFileTokenFormattingRule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Formatting\Rules\IndentBlockFormattingRule.cs" />

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingService.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/CSharpSyntaxFormattingService.cs
@@ -40,6 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Formatting
             _rules = ImmutableList.Create<AbstractFormattingRule>(
                 new WrappingFormattingRule(),
                 new SpacingFormattingRule(),
+                new CSharpNewlineFormattingRule(),
                 new NewLineUserSettingFormattingRule(),
                 new IndentUserSettingsFormattingRule(),
                 new ElasticTriviaFormattingRule(),

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/CSharpNewlineFormattingRule.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Formatting/Rules/CSharpNewlineFormattingRule.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting.Rules;
+using Microsoft.CodeAnalysis.Shared.Utilities;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+using Microsoft.CodeAnalysis.CSharp.Extensions;
+
+namespace Microsoft.CodeAnalysis.CSharp.Formatting
+{
+    internal class CSharpNewlineFormattingRule : BaseFormattingRule
+    {
+        internal CSharpNewlineFormattingRule()
+        {
+        }
+
+        public override AdjustNewLinesOperation GetAdjustNewLinesOperation(in SyntaxToken previousToken, in SyntaxToken currentToken, in NextGetAdjustNewLinesOperation nextOperation)
+        {
+            var nextToken = currentToken.GetNextToken(includeZeroWidth: false, includeSkipped: false);
+            var prevToken = currentToken.GetPreviousToken(includeZeroWidth: false, includeSkipped: false);
+
+            var nextTokenText = nextToken.Text;
+            var currentTokenText = currentToken.Text;
+            var prevTokenText = prevToken.Text;
+
+            // newline before "import" keyword - if the previous line was another UsingDirective or a NamespaceDeclaration
+            if (currentToken.IsKeyword() && currentToken.Text == "import")
+            {
+                var prevTokenOfInterest = currentToken.FindPreviousToken(t => t.IsKind(SyntaxKind.NamespaceKeyword) || t.Text == "import" || t.IsFirstTokenOnLine(), includeZeroWidth: false, includeSkipped: false);
+                if (prevTokenOfInterest?.IsKind(SyntaxKind.NamespaceKeyword) == true)
+                    return CreateAdjustNewLinesOperation(2, AdjustNewLinesOption.PreserveLines);
+                else if(prevTokenOfInterest?.Text == "import")
+                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
+            }
+            else if (nextToken.IsKeyword() && nextToken.Text == "import")
+            {
+                var prevTokenOfInterest = currentToken.FindPreviousToken(t => t.IsKind(SyntaxKind.NamespaceKeyword) || t.Text == "import" || t.IsFirstTokenOnLine(), includeZeroWidth: false, includeSkipped: false);
+                if (prevTokenOfInterest?.IsKind(SyntaxKind.NamespaceKeyword) == true)
+                    return CreateAdjustNewLinesOperation(2, AdjustNewLinesOption.PreserveLines);
+                else if (prevTokenOfInterest?.Text == "import")
+                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
+            }
+            else if (nextToken.IsKind(SyntaxKind.ClassKeyword))
+            {
+                var prevTokenOfInterest = currentToken.FindPreviousToken(t => t.Text == "import" || t.IsFirstTokenOnLine(), includeZeroWidth: false, includeSkipped: false);
+                if (prevTokenOfInterest?.Text == "import")
+                    return CreateAdjustNewLinesOperation(1, AdjustNewLinesOption.PreserveLines);
+            }
+
+            return base.GetAdjustNewLinesOperation(previousToken, currentToken, nextOperation);
+        }
+    }
+}

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TokenComparer.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Utilities/TokenComparer.cs
@@ -20,20 +20,26 @@ namespace Microsoft.CodeAnalysis.CSharp.Utilities
 
         public int Compare(SyntaxToken x, SyntaxToken y)
         {
-            if (_specialCaseSystem &&
-                x.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UsingKeyword, SyntaxKind.StaticKeyword) &&
-                y.GetPreviousToken(includeSkipped: true).IsKind(SyntaxKind.UsingKeyword, SyntaxKind.StaticKeyword))
+            if (_specialCaseSystem)
             {
-                var token1IsSystem = x.ValueText == nameof(System);
-                var token2IsSystem = y.ValueText == nameof(System);
+                var xPrevToken = x.GetPreviousToken(includeSkipped: true);
+                var yPrevToken = y.GetPreviousToken(includeSkipped: true);
 
-                if (token1IsSystem && !token2IsSystem)
+                if ((xPrevToken.IsKind(SyntaxKind.StaticKeyword) || xPrevToken.Text == "import") &&
+                    (yPrevToken.IsKind(SyntaxKind.StaticKeyword) || yPrevToken.Text == "import")
+                    )
                 {
-                    return -1;
-                }
-                else if (!token1IsSystem && token2IsSystem)
-                {
-                    return 1;
+                    var token1IsSystem = x.ValueText == nameof(System);
+                    var token2IsSystem = y.ValueText == nameof(System);
+
+                    if (token1IsSystem && !token2IsSystem)
+                    {
+                        return -1;
+                    }
+                    else if (!token1IsSystem && token2IsSystem)
+                    {
+                        return 1;
+                    }
                 }
             }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTokenExtensions.cs
@@ -15,17 +15,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
         public static bool IsUsingOrExternKeyword(this SyntaxToken token)
         {
             return
-                token.Kind() == SyntaxKind.UsingKeyword ||
+                token.Kind() == SyntaxKind.ImportKeyword ||
                 token.Kind() == SyntaxKind.ExternKeyword;
         }
 
         public static bool IsUsingKeywordInUsingDirective(this SyntaxToken token)
         {
-            if (token.IsKind(SyntaxKind.UsingKeyword))
+            if (token.IsKind(SyntaxKind.ImportKeyword))
             {
                 var usingDirective = token.GetAncestor<UsingDirectiveSyntax>();
                 if (usingDirective != null &&
-                    usingDirective.UsingKeyword == token)
+                    usingDirective.ImportKeyword == token)
                 {
                     return true;
                 }

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Workspace/CSharp/Extensions/ContextQuery/SyntaxTreeExtensions.cs
@@ -701,7 +701,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Extensions.ContextQuery
             // Note: we take care of the using alias case in the IsTypeContext
             // call below.
 
-            if (token.IsKind(SyntaxKind.UsingKeyword))
+            if (token.IsKind(SyntaxKind.ImportKeyword))
             {
                 var usingDirective = token.GetAncestor<UsingDirectiveSyntax>();
                 if (usingDirective != null)


### PR DESCRIPTION
Updates using directive syntax to use "import" keyword rather than "using" keyword to differentiate from local "using statements".

This enables syntax like:

```
namespace testing

// note that we now use import rather than "using System"
import System
import System.Collections

// import all static helpers
import static Utils.Helpers

class MyClass {
}
```