### PR TITLE
Feature/new try catch finally syntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Symbols.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// Bound type if syntax binds to a type in the current context and
         /// null if syntax binds to "var" keyword in the current context.
         /// </returns>
-        internal TypeWithAnnotations BindTypeOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar)
+        internal virtual TypeWithAnnotations BindTypeOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar)
         {
             var symbol = BindTypeOrAliasOrVarKeyword(syntax, diagnostics, out isVar);
             Debug.Assert(isVar == symbol.IsDefault);

--- a/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
+++ b/src/Compilers/CSharp/Portable/Binder/CatchClauseBinder.cs
@@ -40,6 +40,17 @@ namespace Microsoft.CodeAnalysis.CSharp
             return locals.ToImmutableAndFree();
         }
 
+        internal override TypeWithAnnotations BindTypeOrVarKeyword(TypeSyntax syntax, DiagnosticBag diagnostics, out bool isVar)
+        {
+            if (_syntax.Declaration != null && syntax == _syntax.Declaration.Type && !_syntax.Declaration.HasExplicitType())
+            {
+                isVar = false;
+                return BindCatchDeclType(_syntax.Declaration, diagnostics);
+            }
+
+            return base.BindTypeOrVarKeyword(syntax, diagnostics, out isVar);
+        }
+
         internal override ImmutableArray<LocalSymbol> GetDeclaredLocalsForScope(SyntaxNode scopeDesignator)
         {
             if (_syntax == scopeDesignator)

--- a/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
+++ b/src/Compilers/CSharp/Portable/CodeGen/EmitStatement.cs
@@ -932,7 +932,7 @@ oneMoreTime:
                 // Also in Dev12 the exception variable scope span starts right after the stloc instruction and 
                 // ends right before leave instruction. So when stopped at the sequence point Dev12 inserts,
                 // the exception variable is not visible. 
-                if (_emitPdbSequencePoints)
+                if (_emitPdbSequencePoints && !catchBlock.WasCompilerGenerated)
                 {
                     var syntax = catchBlock.Syntax as CatchClauseSyntax;
                     if (syntax != null)

--- a/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
+++ b/src/Compilers/CSharp/Portable/Compilation/MemberSemanticModel.cs
@@ -2429,7 +2429,6 @@ foundParent:;
 
                 block = base.BindEmbeddedBlock(node, diagnostics);
 
-                Debug.Assert(!block.WasCompilerGenerated);
                 return block;
             }
 

--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -644,11 +644,11 @@ catch_clause
   ;
 
 catch_declaration
-  : '(' type identifier_token? ')'
+  : '('? identifier_token? type ')'?
   ;
 
 catch_filter_clause
-  : 'when' '(' expression ')'
+  : 'when' '('? expression ')'?
   ;
 
 finally_clause

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -18317,74 +18317,92 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal sealed partial class CatchDeclarationSyntax : CSharpSyntaxNode
     {
-        internal readonly SyntaxToken openParenToken;
-        internal readonly TypeSyntax type;
+        internal readonly SyntaxToken? openParenToken;
         internal readonly SyntaxToken? identifier;
-        internal readonly SyntaxToken closeParenToken;
+        internal readonly TypeSyntax type;
+        internal readonly SyntaxToken? closeParenToken;
 
-        internal CatchDeclarationSyntax(SyntaxKind kind, SyntaxToken openParenToken, TypeSyntax type, SyntaxToken? identifier, SyntaxToken closeParenToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal CatchDeclarationSyntax(SyntaxKind kind, SyntaxToken? openParenToken, SyntaxToken? identifier, TypeSyntax type, SyntaxToken? closeParenToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
             this.SlotCount = 4;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
-            this.AdjustFlagsAndWidth(type);
-            this.type = type;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             if (identifier != null)
             {
                 this.AdjustFlagsAndWidth(identifier);
                 this.identifier = identifier;
             }
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            this.AdjustFlagsAndWidth(type);
+            this.type = type;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
-        internal CatchDeclarationSyntax(SyntaxKind kind, SyntaxToken openParenToken, TypeSyntax type, SyntaxToken? identifier, SyntaxToken closeParenToken, SyntaxFactoryContext context)
+        internal CatchDeclarationSyntax(SyntaxKind kind, SyntaxToken? openParenToken, SyntaxToken? identifier, TypeSyntax type, SyntaxToken? closeParenToken, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
             this.SlotCount = 4;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
-            this.AdjustFlagsAndWidth(type);
-            this.type = type;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             if (identifier != null)
             {
                 this.AdjustFlagsAndWidth(identifier);
                 this.identifier = identifier;
             }
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            this.AdjustFlagsAndWidth(type);
+            this.type = type;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
-        internal CatchDeclarationSyntax(SyntaxKind kind, SyntaxToken openParenToken, TypeSyntax type, SyntaxToken? identifier, SyntaxToken closeParenToken)
+        internal CatchDeclarationSyntax(SyntaxKind kind, SyntaxToken? openParenToken, SyntaxToken? identifier, TypeSyntax type, SyntaxToken? closeParenToken)
           : base(kind)
         {
             this.SlotCount = 4;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
-            this.AdjustFlagsAndWidth(type);
-            this.type = type;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             if (identifier != null)
             {
                 this.AdjustFlagsAndWidth(identifier);
                 this.identifier = identifier;
             }
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            this.AdjustFlagsAndWidth(type);
+            this.type = type;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
-        public SyntaxToken OpenParenToken => this.openParenToken;
-        public TypeSyntax Type => this.type;
+        public SyntaxToken? OpenParenToken => this.openParenToken;
         public SyntaxToken? Identifier => this.identifier;
-        public SyntaxToken CloseParenToken => this.closeParenToken;
+        public TypeSyntax Type => this.type;
+        public SyntaxToken? CloseParenToken => this.closeParenToken;
 
         internal override GreenNode? GetSlot(int index)
             => index switch
             {
                 0 => this.openParenToken,
-                1 => this.type,
-                2 => this.identifier,
+                1 => this.identifier,
+                2 => this.type,
                 3 => this.closeParenToken,
                 _ => null,
             };
@@ -18394,11 +18412,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitCatchDeclaration(this);
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitCatchDeclaration(this);
 
-        public CatchDeclarationSyntax Update(SyntaxToken openParenToken, TypeSyntax type, SyntaxToken identifier, SyntaxToken closeParenToken)
+        public CatchDeclarationSyntax Update(SyntaxToken openParenToken, SyntaxToken identifier, TypeSyntax type, SyntaxToken closeParenToken)
         {
-            if (openParenToken != this.OpenParenToken || type != this.Type || identifier != this.Identifier || closeParenToken != this.CloseParenToken)
+            if (openParenToken != this.OpenParenToken || identifier != this.Identifier || type != this.Type || closeParenToken != this.CloseParenToken)
             {
-                var newNode = SyntaxFactory.CatchDeclaration(openParenToken, type, identifier, closeParenToken);
+                var newNode = SyntaxFactory.CatchDeclaration(openParenToken, identifier, type, closeParenToken);
                 var diags = GetDiagnostics();
                 if (diags?.Length > 0)
                     newNode = newNode.WithDiagnosticsGreen(diags);
@@ -18412,38 +18430,44 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-            => new CatchDeclarationSyntax(this.Kind, this.openParenToken, this.type, this.identifier, this.closeParenToken, diagnostics, GetAnnotations());
+            => new CatchDeclarationSyntax(this.Kind, this.openParenToken, this.identifier, this.type, this.closeParenToken, diagnostics, GetAnnotations());
 
         internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-            => new CatchDeclarationSyntax(this.Kind, this.openParenToken, this.type, this.identifier, this.closeParenToken, GetDiagnostics(), annotations);
+            => new CatchDeclarationSyntax(this.Kind, this.openParenToken, this.identifier, this.type, this.closeParenToken, GetDiagnostics(), annotations);
 
         internal CatchDeclarationSyntax(ObjectReader reader)
           : base(reader)
         {
             this.SlotCount = 4;
-            var openParenToken = (SyntaxToken)reader.ReadValue();
-            AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
-            var type = (TypeSyntax)reader.ReadValue();
-            AdjustFlagsAndWidth(type);
-            this.type = type;
+            var openParenToken = (SyntaxToken?)reader.ReadValue();
+            if (openParenToken != null)
+            {
+                AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             var identifier = (SyntaxToken?)reader.ReadValue();
             if (identifier != null)
             {
                 AdjustFlagsAndWidth(identifier);
                 this.identifier = identifier;
             }
-            var closeParenToken = (SyntaxToken)reader.ReadValue();
-            AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            var type = (TypeSyntax)reader.ReadValue();
+            AdjustFlagsAndWidth(type);
+            this.type = type;
+            var closeParenToken = (SyntaxToken?)reader.ReadValue();
+            if (closeParenToken != null)
+            {
+                AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
         internal override void WriteTo(ObjectWriter writer)
         {
             base.WriteTo(writer);
             writer.WriteValue(this.openParenToken);
-            writer.WriteValue(this.type);
             writer.WriteValue(this.identifier);
+            writer.WriteValue(this.type);
             writer.WriteValue(this.closeParenToken);
         }
 
@@ -18456,57 +18480,75 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     internal sealed partial class CatchFilterClauseSyntax : CSharpSyntaxNode
     {
         internal readonly SyntaxToken whenKeyword;
-        internal readonly SyntaxToken openParenToken;
+        internal readonly SyntaxToken? openParenToken;
         internal readonly ExpressionSyntax filterExpression;
-        internal readonly SyntaxToken closeParenToken;
+        internal readonly SyntaxToken? closeParenToken;
 
-        internal CatchFilterClauseSyntax(SyntaxKind kind, SyntaxToken whenKeyword, SyntaxToken openParenToken, ExpressionSyntax filterExpression, SyntaxToken closeParenToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal CatchFilterClauseSyntax(SyntaxKind kind, SyntaxToken whenKeyword, SyntaxToken? openParenToken, ExpressionSyntax filterExpression, SyntaxToken? closeParenToken, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
             this.SlotCount = 4;
             this.AdjustFlagsAndWidth(whenKeyword);
             this.whenKeyword = whenKeyword;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             this.AdjustFlagsAndWidth(filterExpression);
             this.filterExpression = filterExpression;
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
-        internal CatchFilterClauseSyntax(SyntaxKind kind, SyntaxToken whenKeyword, SyntaxToken openParenToken, ExpressionSyntax filterExpression, SyntaxToken closeParenToken, SyntaxFactoryContext context)
+        internal CatchFilterClauseSyntax(SyntaxKind kind, SyntaxToken whenKeyword, SyntaxToken? openParenToken, ExpressionSyntax filterExpression, SyntaxToken? closeParenToken, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
             this.SlotCount = 4;
             this.AdjustFlagsAndWidth(whenKeyword);
             this.whenKeyword = whenKeyword;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             this.AdjustFlagsAndWidth(filterExpression);
             this.filterExpression = filterExpression;
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
-        internal CatchFilterClauseSyntax(SyntaxKind kind, SyntaxToken whenKeyword, SyntaxToken openParenToken, ExpressionSyntax filterExpression, SyntaxToken closeParenToken)
+        internal CatchFilterClauseSyntax(SyntaxKind kind, SyntaxToken whenKeyword, SyntaxToken? openParenToken, ExpressionSyntax filterExpression, SyntaxToken? closeParenToken)
           : base(kind)
         {
             this.SlotCount = 4;
             this.AdjustFlagsAndWidth(whenKeyword);
             this.whenKeyword = whenKeyword;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             this.AdjustFlagsAndWidth(filterExpression);
             this.filterExpression = filterExpression;
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
         public SyntaxToken WhenKeyword => this.whenKeyword;
-        public SyntaxToken OpenParenToken => this.openParenToken;
+        public SyntaxToken? OpenParenToken => this.openParenToken;
         public ExpressionSyntax FilterExpression => this.filterExpression;
-        public SyntaxToken CloseParenToken => this.closeParenToken;
+        public SyntaxToken? CloseParenToken => this.closeParenToken;
 
         internal override GreenNode? GetSlot(int index)
             => index switch
@@ -18553,15 +18595,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             var whenKeyword = (SyntaxToken)reader.ReadValue();
             AdjustFlagsAndWidth(whenKeyword);
             this.whenKeyword = whenKeyword;
-            var openParenToken = (SyntaxToken)reader.ReadValue();
-            AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            var openParenToken = (SyntaxToken?)reader.ReadValue();
+            if (openParenToken != null)
+            {
+                AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             var filterExpression = (ExpressionSyntax)reader.ReadValue();
             AdjustFlagsAndWidth(filterExpression);
             this.filterExpression = filterExpression;
-            var closeParenToken = (SyntaxToken)reader.ReadValue();
-            AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            var closeParenToken = (SyntaxToken?)reader.ReadValue();
+            if (closeParenToken != null)
+            {
+                AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
         }
 
         internal override void WriteTo(ObjectWriter writer)
@@ -33666,7 +33714,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             => node.Update((SyntaxToken)Visit(node.CatchKeyword), (CatchDeclarationSyntax)Visit(node.Declaration), (CatchFilterClauseSyntax)Visit(node.Filter), (BlockSyntax)Visit(node.Block));
 
         public override CSharpSyntaxNode VisitCatchDeclaration(CatchDeclarationSyntax node)
-            => node.Update((SyntaxToken)Visit(node.OpenParenToken), (TypeSyntax)Visit(node.Type), (SyntaxToken)Visit(node.Identifier), (SyntaxToken)Visit(node.CloseParenToken));
+            => node.Update((SyntaxToken)Visit(node.OpenParenToken), (SyntaxToken)Visit(node.Identifier), (TypeSyntax)Visit(node.Type), (SyntaxToken)Visit(node.CloseParenToken));
 
         public override CSharpSyntaxNode VisitCatchFilterClause(CatchFilterClauseSyntax node)
             => node.Update((SyntaxToken)Visit(node.WhenKeyword), (SyntaxToken)Visit(node.OpenParenToken), (ExpressionSyntax)Visit(node.FilterExpression), (SyntaxToken)Visit(node.CloseParenToken));
@@ -36885,12 +36933,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new CatchClauseSyntax(SyntaxKind.CatchClause, catchKeyword, declaration, filter, block, this.context);
         }
 
-        public CatchDeclarationSyntax CatchDeclaration(SyntaxToken openParenToken, TypeSyntax type, SyntaxToken? identifier, SyntaxToken closeParenToken)
+        public CatchDeclarationSyntax CatchDeclaration(SyntaxToken? openParenToken, SyntaxToken? identifier, TypeSyntax type, SyntaxToken? closeParenToken)
         {
 #if DEBUG
-            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
-            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
-            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (openParenToken != null)
+            {
+                switch (openParenToken.Kind)
+                {
+                    case SyntaxKind.OpenParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(openParenToken));
+                }
+            }
             if (identifier != null)
             {
                 switch (identifier.Kind)
@@ -36900,23 +36954,45 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     default: throw new ArgumentException(nameof(identifier));
                 }
             }
-            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
-            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (closeParenToken != null)
+            {
+                switch (closeParenToken.Kind)
+                {
+                    case SyntaxKind.CloseParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(closeParenToken));
+                }
+            }
 #endif
 
-            return new CatchDeclarationSyntax(SyntaxKind.CatchDeclaration, openParenToken, type, identifier, closeParenToken, this.context);
+            return new CatchDeclarationSyntax(SyntaxKind.CatchDeclaration, openParenToken, identifier, type, closeParenToken, this.context);
         }
 
-        public CatchFilterClauseSyntax CatchFilterClause(SyntaxToken whenKeyword, SyntaxToken openParenToken, ExpressionSyntax filterExpression, SyntaxToken closeParenToken)
+        public CatchFilterClauseSyntax CatchFilterClause(SyntaxToken whenKeyword, SyntaxToken? openParenToken, ExpressionSyntax filterExpression, SyntaxToken? closeParenToken)
         {
 #if DEBUG
             if (whenKeyword == null) throw new ArgumentNullException(nameof(whenKeyword));
             if (whenKeyword.Kind != SyntaxKind.WhenKeyword) throw new ArgumentException(nameof(whenKeyword));
-            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
-            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (openParenToken != null)
+            {
+                switch (openParenToken.Kind)
+                {
+                    case SyntaxKind.OpenParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(openParenToken));
+                }
+            }
             if (filterExpression == null) throw new ArgumentNullException(nameof(filterExpression));
-            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
-            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            if (closeParenToken != null)
+            {
+                switch (closeParenToken.Kind)
+                {
+                    case SyntaxKind.CloseParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(closeParenToken));
+                }
+            }
 #endif
 
             return new CatchFilterClauseSyntax(SyntaxKind.CatchFilterClause, whenKeyword, openParenToken, filterExpression, closeParenToken, this.context);
@@ -41748,12 +41824,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new CatchClauseSyntax(SyntaxKind.CatchClause, catchKeyword, declaration, filter, block);
         }
 
-        public static CatchDeclarationSyntax CatchDeclaration(SyntaxToken openParenToken, TypeSyntax type, SyntaxToken? identifier, SyntaxToken closeParenToken)
+        public static CatchDeclarationSyntax CatchDeclaration(SyntaxToken? openParenToken, SyntaxToken? identifier, TypeSyntax type, SyntaxToken? closeParenToken)
         {
 #if DEBUG
-            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
-            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
-            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (openParenToken != null)
+            {
+                switch (openParenToken.Kind)
+                {
+                    case SyntaxKind.OpenParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(openParenToken));
+                }
+            }
             if (identifier != null)
             {
                 switch (identifier.Kind)
@@ -41763,23 +41845,45 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     default: throw new ArgumentException(nameof(identifier));
                 }
             }
-            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
-            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            if (closeParenToken != null)
+            {
+                switch (closeParenToken.Kind)
+                {
+                    case SyntaxKind.CloseParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(closeParenToken));
+                }
+            }
 #endif
 
-            return new CatchDeclarationSyntax(SyntaxKind.CatchDeclaration, openParenToken, type, identifier, closeParenToken);
+            return new CatchDeclarationSyntax(SyntaxKind.CatchDeclaration, openParenToken, identifier, type, closeParenToken);
         }
 
-        public static CatchFilterClauseSyntax CatchFilterClause(SyntaxToken whenKeyword, SyntaxToken openParenToken, ExpressionSyntax filterExpression, SyntaxToken closeParenToken)
+        public static CatchFilterClauseSyntax CatchFilterClause(SyntaxToken whenKeyword, SyntaxToken? openParenToken, ExpressionSyntax filterExpression, SyntaxToken? closeParenToken)
         {
 #if DEBUG
             if (whenKeyword == null) throw new ArgumentNullException(nameof(whenKeyword));
             if (whenKeyword.Kind != SyntaxKind.WhenKeyword) throw new ArgumentException(nameof(whenKeyword));
-            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
-            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (openParenToken != null)
+            {
+                switch (openParenToken.Kind)
+                {
+                    case SyntaxKind.OpenParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(openParenToken));
+                }
+            }
             if (filterExpression == null) throw new ArgumentNullException(nameof(filterExpression));
-            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
-            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            if (closeParenToken != null)
+            {
+                switch (closeParenToken.Kind)
+                {
+                    case SyntaxKind.CloseParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(closeParenToken));
+                }
+            }
 #endif
 
             return new CatchFilterClauseSyntax(SyntaxKind.CatchFilterClause, whenKeyword, openParenToken, filterExpression, closeParenToken);

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -2019,7 +2019,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => node.Update(VisitToken(node.CatchKeyword), (CatchDeclarationSyntax?)Visit(node.Declaration), (CatchFilterClauseSyntax?)Visit(node.Filter), (BlockSyntax?)Visit(node.Block) ?? throw new ArgumentNullException("block"));
 
         public override SyntaxNode? VisitCatchDeclaration(CatchDeclarationSyntax node)
-            => node.Update(VisitToken(node.OpenParenToken), (TypeSyntax?)Visit(node.Type) ?? throw new ArgumentNullException("type"), VisitToken(node.Identifier), VisitToken(node.CloseParenToken));
+            => node.Update(VisitToken(node.OpenParenToken), VisitToken(node.Identifier), (TypeSyntax?)Visit(node.Type) ?? throw new ArgumentNullException("type"), VisitToken(node.CloseParenToken));
 
         public override SyntaxNode? VisitCatchFilterClause(CatchFilterClauseSyntax node)
             => node.Update(VisitToken(node.WhenKeyword), VisitToken(node.OpenParenToken), (ExpressionSyntax?)Visit(node.FilterExpression) ?? throw new ArgumentNullException("filterExpression"), VisitToken(node.CloseParenToken));
@@ -4664,41 +4664,61 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SyntaxFactory.CatchClause(SyntaxFactory.Token(SyntaxKind.CatchKeyword), default, default, SyntaxFactory.Block());
 
         /// <summary>Creates a new CatchDeclarationSyntax instance.</summary>
-        public static CatchDeclarationSyntax CatchDeclaration(SyntaxToken openParenToken, TypeSyntax type, SyntaxToken identifier, SyntaxToken closeParenToken)
+        public static CatchDeclarationSyntax CatchDeclaration(SyntaxToken openParenToken, SyntaxToken identifier, TypeSyntax type, SyntaxToken closeParenToken)
         {
-            if (openParenToken.Kind() != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
-            if (type == null) throw new ArgumentNullException(nameof(type));
+            switch (openParenToken.Kind())
+            {
+                case SyntaxKind.OpenParenToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(openParenToken));
+            }
             switch (identifier.Kind())
             {
                 case SyntaxKind.IdentifierToken:
                 case SyntaxKind.None: break;
                 default: throw new ArgumentException(nameof(identifier));
             }
-            if (closeParenToken.Kind() != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
-            return (CatchDeclarationSyntax)Syntax.InternalSyntax.SyntaxFactory.CatchDeclaration((Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, (Syntax.InternalSyntax.TypeSyntax)type.Green, (Syntax.InternalSyntax.SyntaxToken?)identifier.Node, (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!).CreateRed();
+            if (type == null) throw new ArgumentNullException(nameof(type));
+            switch (closeParenToken.Kind())
+            {
+                case SyntaxKind.CloseParenToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(closeParenToken));
+            }
+            return (CatchDeclarationSyntax)Syntax.InternalSyntax.SyntaxFactory.CatchDeclaration((Syntax.InternalSyntax.SyntaxToken?)openParenToken.Node, (Syntax.InternalSyntax.SyntaxToken?)identifier.Node, (Syntax.InternalSyntax.TypeSyntax)type.Green, (Syntax.InternalSyntax.SyntaxToken?)closeParenToken.Node).CreateRed();
         }
 
         /// <summary>Creates a new CatchDeclarationSyntax instance.</summary>
-        public static CatchDeclarationSyntax CatchDeclaration(TypeSyntax type, SyntaxToken identifier)
-            => SyntaxFactory.CatchDeclaration(SyntaxFactory.Token(SyntaxKind.OpenParenToken), type, identifier, SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+        public static CatchDeclarationSyntax CatchDeclaration(SyntaxToken identifier, TypeSyntax type)
+            => SyntaxFactory.CatchDeclaration(default, identifier, type, default);
 
         /// <summary>Creates a new CatchDeclarationSyntax instance.</summary>
         public static CatchDeclarationSyntax CatchDeclaration(TypeSyntax type)
-            => SyntaxFactory.CatchDeclaration(SyntaxFactory.Token(SyntaxKind.OpenParenToken), type, default, SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => SyntaxFactory.CatchDeclaration(default, default, type, default);
 
         /// <summary>Creates a new CatchFilterClauseSyntax instance.</summary>
         public static CatchFilterClauseSyntax CatchFilterClause(SyntaxToken whenKeyword, SyntaxToken openParenToken, ExpressionSyntax filterExpression, SyntaxToken closeParenToken)
         {
             if (whenKeyword.Kind() != SyntaxKind.WhenKeyword) throw new ArgumentException(nameof(whenKeyword));
-            if (openParenToken.Kind() != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            switch (openParenToken.Kind())
+            {
+                case SyntaxKind.OpenParenToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(openParenToken));
+            }
             if (filterExpression == null) throw new ArgumentNullException(nameof(filterExpression));
-            if (closeParenToken.Kind() != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
-            return (CatchFilterClauseSyntax)Syntax.InternalSyntax.SyntaxFactory.CatchFilterClause((Syntax.InternalSyntax.SyntaxToken)whenKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, (Syntax.InternalSyntax.ExpressionSyntax)filterExpression.Green, (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!).CreateRed();
+            switch (closeParenToken.Kind())
+            {
+                case SyntaxKind.CloseParenToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(closeParenToken));
+            }
+            return (CatchFilterClauseSyntax)Syntax.InternalSyntax.SyntaxFactory.CatchFilterClause((Syntax.InternalSyntax.SyntaxToken)whenKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken?)openParenToken.Node, (Syntax.InternalSyntax.ExpressionSyntax)filterExpression.Green, (Syntax.InternalSyntax.SyntaxToken?)closeParenToken.Node).CreateRed();
         }
 
         /// <summary>Creates a new CatchFilterClauseSyntax instance.</summary>
         public static CatchFilterClauseSyntax CatchFilterClause(ExpressionSyntax filterExpression)
-            => SyntaxFactory.CatchFilterClause(SyntaxFactory.Token(SyntaxKind.WhenKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), filterExpression, SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => SyntaxFactory.CatchFilterClause(SyntaxFactory.Token(SyntaxKind.WhenKeyword), default, filterExpression, default);
 
         /// <summary>Creates a new FinallyClauseSyntax instance.</summary>
         public static FinallyClauseSyntax FinallyClause(SyntaxToken finallyKeyword, BlockSyntax block)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -7871,34 +7871,48 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
         }
 
-        public SyntaxToken OpenParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.CatchDeclarationSyntax)this.Green).openParenToken, Position, 0);
-
-        public TypeSyntax Type => GetRed(ref this.type, 1)!;
+        public SyntaxToken OpenParenToken
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.CatchDeclarationSyntax)this.Green).openParenToken;
+                return slot != null ? new SyntaxToken(this, slot, Position, 0) : default;
+            }
+        }
 
         public SyntaxToken Identifier
         {
             get
             {
                 var slot = ((Syntax.InternalSyntax.CatchDeclarationSyntax)this.Green).identifier;
-                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(2), GetChildIndex(2)) : default;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(1), GetChildIndex(1)) : default;
             }
         }
 
-        public SyntaxToken CloseParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.CatchDeclarationSyntax)this.Green).closeParenToken, GetChildPosition(3), GetChildIndex(3));
+        public TypeSyntax Type => GetRed(ref this.type, 2)!;
 
-        internal override SyntaxNode? GetNodeSlot(int index) => index == 1 ? GetRed(ref this.type, 1)! : null;
+        public SyntaxToken CloseParenToken
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.CatchDeclarationSyntax)this.Green).closeParenToken;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(3), GetChildIndex(3)) : default;
+            }
+        }
 
-        internal override SyntaxNode? GetCachedSlot(int index) => index == 1 ? this.type : null;
+        internal override SyntaxNode? GetNodeSlot(int index) => index == 2 ? GetRed(ref this.type, 2)! : null;
+
+        internal override SyntaxNode? GetCachedSlot(int index) => index == 2 ? this.type : null;
 
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitCatchDeclaration(this);
         [return: MaybeNull]
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitCatchDeclaration(this);
 
-        public CatchDeclarationSyntax Update(SyntaxToken openParenToken, TypeSyntax type, SyntaxToken identifier, SyntaxToken closeParenToken)
+        public CatchDeclarationSyntax Update(SyntaxToken openParenToken, SyntaxToken identifier, TypeSyntax type, SyntaxToken closeParenToken)
         {
-            if (openParenToken != this.OpenParenToken || type != this.Type || identifier != this.Identifier || closeParenToken != this.CloseParenToken)
+            if (openParenToken != this.OpenParenToken || identifier != this.Identifier || type != this.Type || closeParenToken != this.CloseParenToken)
             {
-                var newNode = SyntaxFactory.CatchDeclaration(openParenToken, type, identifier, closeParenToken);
+                var newNode = SyntaxFactory.CatchDeclaration(openParenToken, identifier, type, closeParenToken);
                 var annotations = GetAnnotations();
                 return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
             }
@@ -7906,10 +7920,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return this;
         }
 
-        public CatchDeclarationSyntax WithOpenParenToken(SyntaxToken openParenToken) => Update(openParenToken, this.Type, this.Identifier, this.CloseParenToken);
-        public CatchDeclarationSyntax WithType(TypeSyntax type) => Update(this.OpenParenToken, type, this.Identifier, this.CloseParenToken);
-        public CatchDeclarationSyntax WithIdentifier(SyntaxToken identifier) => Update(this.OpenParenToken, this.Type, identifier, this.CloseParenToken);
-        public CatchDeclarationSyntax WithCloseParenToken(SyntaxToken closeParenToken) => Update(this.OpenParenToken, this.Type, this.Identifier, closeParenToken);
+        public CatchDeclarationSyntax WithOpenParenToken(SyntaxToken openParenToken) => Update(openParenToken, this.Identifier, this.Type, this.CloseParenToken);
+        public CatchDeclarationSyntax WithIdentifier(SyntaxToken identifier) => Update(this.OpenParenToken, identifier, this.Type, this.CloseParenToken);
+        public CatchDeclarationSyntax WithType(TypeSyntax type) => Update(this.OpenParenToken, this.Identifier, type, this.CloseParenToken);
+        public CatchDeclarationSyntax WithCloseParenToken(SyntaxToken closeParenToken) => Update(this.OpenParenToken, this.Identifier, this.Type, closeParenToken);
     }
 
     public sealed partial class CatchFilterClauseSyntax : CSharpSyntaxNode
@@ -7923,11 +7937,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         public SyntaxToken WhenKeyword => new SyntaxToken(this, ((Syntax.InternalSyntax.CatchFilterClauseSyntax)this.Green).whenKeyword, Position, 0);
 
-        public SyntaxToken OpenParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.CatchFilterClauseSyntax)this.Green).openParenToken, GetChildPosition(1), GetChildIndex(1));
+        public SyntaxToken OpenParenToken
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.CatchFilterClauseSyntax)this.Green).openParenToken;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(1), GetChildIndex(1)) : default;
+            }
+        }
 
         public ExpressionSyntax FilterExpression => GetRed(ref this.filterExpression, 2)!;
 
-        public SyntaxToken CloseParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.CatchFilterClauseSyntax)this.Green).closeParenToken, GetChildPosition(3), GetChildIndex(3));
+        public SyntaxToken CloseParenToken
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.CatchFilterClauseSyntax)this.Green).closeParenToken;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(3), GetChildIndex(3)) : default;
+            }
+        }
 
         internal override SyntaxNode? GetNodeSlot(int index) => index == 2 ? GetRed(ref this.filterExpression, 2)! : null;
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -7180,7 +7180,7 @@ done:
             FirstElementOfPossibleTupleLiteral,
         }
 
-        private TypeSyntax TryParseType(ParseTypeMode mode = ParseTypeMode.Normal, bool allowVoid = true)
+        private TypeSyntax TryParseType(ParseTypeMode mode = ParseTypeMode.Normal, bool allowVoid = true, bool allowKeywordName = true)
         {
             if (allowVoid)
             {
@@ -7195,9 +7195,25 @@ done:
             var resetPoint = GetResetPoint();
             var parsedType = ParseType(mode);
             if (parsedType == null || parsedType.IsMissing)
+            {
                 Reset(ref resetPoint);
+            }
             else
+            {
                 type = parsedType;
+
+                // verify we didn't use a contextual name
+                if (!allowKeywordName && type is SimpleNameSyntax typeName)
+                {
+                    var name = typeName.Identifier?.Text;
+                    var kwKind = SyntaxFacts.GetContextualKeywordKind(name);
+                    if (kwKind != SyntaxKind.None)
+                    {
+                        Reset(ref resetPoint);
+                        type = null;
+                    }
+                }
+            }
             Release(ref resetPoint);
             return type;
         }
@@ -7841,7 +7857,7 @@ done:;
                     case SyntaxKind.TryKeyword:
                     case SyntaxKind.CatchKeyword:
                     case SyntaxKind.FinallyKeyword:
-                        return this.ParseTryStatement(attributes);
+                        return this.ParseTryCatchStatement(attributes);
                     case SyntaxKind.CheckedKeyword:
                     case SyntaxKind.UncheckedKeyword:
                         return this.ParseCheckedStatement(attributes);
@@ -8821,7 +8837,12 @@ done:;
             return null;
         }
 
-        private BlockSyntax ParsePossiblyAttributedBlock() => ParseBlock(this.ParseAttributeDeclarations());
+        private BlockSyntax ParsePossiblyAttributedBlock(SyntaxList<AttributeListSyntax> attributes = default)
+        {
+            if (attributes.Count == 0)
+                attributes = this.ParseAttributeDeclarations();
+            return ParseBlock(attributes);
+        }
 
         /// <summary>
         /// Used to parse the block-body for a method or accessor.  For blocks that appear *inside*
@@ -9123,33 +9144,38 @@ done:;
             return _syntaxFactory.ContinueStatement(attributes, continueKeyword, semicolon);
         }
 
+        #region try/catch/finally statement
+
         private TryStatementSyntax ParseTryCatchStatement(SyntaxList<AttributeListSyntax> attributes)
         {
-            var ((tryToken, tryBlock), catchClauses, (finallyToken, finallyBlock)) = TryParseTryCatchParts(attributes, parseTry: true, parseCatches: true, parseFinally: true);
+            // parse the different parts of the try / catch construct
+            var ((tryToken, tryBlock), catchClauses, (finallyToken, finallyBlock)) = TryParseTryCatchParts(
+                attributes,
+                parseTry: true,
+                parseCatches: true,
+                parseFinally: true
+            );
 
             FinallyClauseSyntax finallyClause = null;
 
-            // make sure we close the try block - must either exist a "catch" or "finally" block ... otherwise we will need to append a missing "finally" block ...
-            var hasCatches = catchClauses?.Count > 0;
-            if (finallyBlock == null && !hasCatches && tryBlock != null)
-            {
-                tryBlock = this.AddErrorToLastToken(tryBlock, ErrorCode.ERR_ExpectedEndTry);
-
-                // synthesize missing tokens for "finally { }":
-                finallyClause = _syntaxFactory.FinallyClause(
-                    SyntaxToken.CreateMissing(SyntaxKind.FinallyKeyword, null, null),
-                    _syntaxFactory.Block(
-                        attributeLists: default,
-                        SyntaxToken.CreateMissing(SyntaxKind.OpenBraceToken, null, null),
-                        default(SyntaxList<StatementSyntax>),
-                        SyntaxToken.CreateMissing(SyntaxKind.CloseBraceToken, null, null)));
-            }
-            else
+            // create the finally clause if we have a finally block
+            if (finallyBlock != null)
             {
                 // we have the finally block
                 finallyClause = _syntaxFactory.FinallyClause(finallyToken, finallyBlock);
             }
 
+            // make sure we close the try block - must either exist a "catch" or "finally" block ... otherwise we will need to append a missing "finally" block ...
+            var hasCatches = catchClauses?.Count > 0;
+            if (finallyBlock == null && !hasCatches && tryBlock != null)
+            {
+                finallyClause = _syntaxFactory.FinallyClause(
+                    finallyKeyword: SyntaxFactory.FakeToken(SyntaxKind.FinallyKeyword),
+                    block: SyntaxFactory.FakeBlock()
+                );
+            }
+
+            // we are done
             return _syntaxFactory.TryStatement(attributes, tryToken, tryBlock, catchClauses ?? default, finallyClause);
         }
 
@@ -9172,17 +9198,19 @@ done:;
 
                 if (parseTry)
                 {
-                    (tryToken, tryBlock) = ParseTryBlock();
+                    (tryToken, tryBlock) = ParseTryBlock(attributes);
+                    attributes = default;
                 }
 
                 if (parseCatches)
                 {
                     catches = ParseCatchClauses();
+                    attributes = default;
                 }
 
                 if (parseFinally)
                 {
-                    (finallyToken, finallyBlock) = ParseFinallyBlock();
+                    (finallyToken, finallyBlock) = ParseFinallyBlock(attributes);
                 }
 
                 return ((tryToken, tryBlock), catches, (finallyToken, finallyBlock));
@@ -9193,45 +9221,90 @@ done:;
             }
         }
 
-        private (SyntaxToken, BlockSyntax) ParseTryBlock()
+        #region try
+        private (SyntaxToken, BlockSyntax) ParseTryBlock(SyntaxList<AttributeListSyntax> attributes = default)
         {
+            if (CurrentToken.Kind != SyntaxKind.TryKeyword) return (null, null);
+
             SyntaxToken tryToken = null;
             BlockSyntax tryBlock = null;
-
-            if (CurrentToken.Kind == SyntaxKind.TryKeyword) return (null, null);
 
             // parse the "try" token
             tryToken = this.EatToken(SyntaxKind.TryKeyword);
 
-            if (CurrentToken.Kind != SyntaxKind.OpenBraceToken)
+            // we should be at an { or => token to proceed ... otherwise we will just stop and continue
+            if (CurrentKind != SyntaxKind.OpenBraceToken && CurrentKind != SyntaxKind.EqualsGreaterThanToken)
             {
+                // we also allow simple "try DoSomeExpression()" ... which means that if we are at an identifier, then we will try to parse a simple expression
+                if (CurrentKind == SyntaxKind.IdentifierToken)
+                {
+                    var resetPoint = GetResetPoint();
+                    try
+                    {
+                        var exprStatBlock = ParseExprStatementBlock(attributes, simpleExpr: true);
+                        if (!exprStatBlock.ContainsDiagnostics)
+                        {
+                            // accept the block if no errors
+                            tryBlock = exprStatBlock;
+                            attributes = default;
+                        }
+                        else
+                        {
+                            // undo the expr parsing ... we will skip the syntax and say missing block later ...
+                            Reset(ref resetPoint);
+                        }
+                    }
+                    finally
+                    {
+                        Release(ref resetPoint);
+                    }
+                }
+
                 // skip until the next possible start
                 var badTokensTrivia = SkipBadTokensUntil(
                     skippedErrorCode: ErrorCode.ERR_UnexpectedToken,
                     untilPredicate: () =>
-                        CurrentToken.Kind == SyntaxKind.OpenBraceToken |
-                        CurrentToken.Kind == SyntaxKind.CatchKeyword |
-                        CurrentToken.Kind == SyntaxKind.FinallyKeyword |
+                        CurrentKind == SyntaxKind.OpenBraceToken ||
+                        CurrentKind == SyntaxKind.EqualsGreaterThanToken ||
+                        CurrentKind == SyntaxKind.CatchKeyword ||
+                        CurrentKind == SyntaxKind.FinallyKeyword ||
                         IsProbablyStatementEnd()
                 );
 
                 // add the skipped tokens
-                tryToken = AddTrailingSkippedSyntax(tryToken, badTokensTrivia);
+                if (tryBlock != null) tryBlock = AddTrailingSkippedSyntax(tryBlock, badTokensTrivia);
+                else tryToken = AddTrailingSkippedSyntax(tryToken, badTokensTrivia);
             }
 
-            // parse the {...} block
-            if (CurrentToken.Kind == SyntaxKind.OpenBraceToken)
+            if (tryBlock == null)
             {
-                var saveTerm = _termState;
-                _termState |= TerminatorState.IsEndOfTryBlock;
-                tryBlock = this.ParsePossiblyAttributedBlock();
-                _termState = saveTerm;
+                // parse the =>, {...} block
+                if (CurrentKind == SyntaxKind.EqualsGreaterThanToken)
+                {
+                    var saveTerm = _termState;
+                    _termState |= TerminatorState.IsEndOfTryBlock;
+
+                    tryBlock = ParseArrowExprStatementBlock(attributes, simpleExpr: true);
+                    attributes = default;
+
+                    _termState = saveTerm;
+                }
+                else if (CurrentKind == SyntaxKind.OpenBraceToken)
+                {
+                    var saveTerm = _termState;
+                    _termState |= TerminatorState.IsEndOfTryBlock;
+
+                    tryBlock = ParsePossiblyAttributedBlock(attributes);
+                    attributes = default;
+
+                    _termState = saveTerm;
+                }
             }
 
             if (tryBlock == null)
             {
                 tryBlock = _syntaxFactory.Block(
-                    attributeLists: default,
+                    attributeLists: attributes,
                     SyntaxToken.CreateMissing(SyntaxKind.OpenBraceToken, null, null),
                     default(SyntaxList<StatementSyntax>),
                     SyntaxToken.CreateMissing(SyntaxKind.CloseBraceToken, null, null)
@@ -9240,7 +9313,9 @@ done:;
 
             return (tryToken, tryBlock);
         }
+        #endregion
 
+        #region catch
         private SyntaxList<CatchClauseSyntax>? ParseCatchClauses()
         {
             SyntaxListBuilder<CatchClauseSyntax> catches = default;
@@ -9250,9 +9325,9 @@ done:;
                 if (this.CurrentToken.Kind == SyntaxKind.CatchKeyword)
                 {
                     catches = _pool.Allocate<CatchClauseSyntax>();
-                    while (this.CurrentToken.Kind == SyntaxKind.CatchKeyword)
+                    while (CurrentToken.Kind == SyntaxKind.CatchKeyword)
                     {
-                        var catchClause = this.ParseCatchClause();
+                        var catchClause = ParseCatchClause();
 
                         try
                         {
@@ -9266,6 +9341,7 @@ done:;
                                     skippedErrorCode: ErrorCode.ERR_UnexpectedToken,
                                     untilPredicate: () =>
                                         CurrentToken.Kind == SyntaxKind.OpenBraceToken |
+                                        CurrentToken.Kind == SyntaxKind.EqualsGreaterThanToken |
                                         CurrentToken.Kind == SyntaxKind.CatchKeyword |
                                         CurrentToken.Kind == SyntaxKind.FinallyKeyword |
                                         IsProbablyStatementEnd()
@@ -9290,40 +9366,324 @@ done:;
             }
         }
 
-        private (SyntaxToken, BlockSyntax) ParseFinallyBlock()
+        private CatchClauseSyntax ParseCatchClause()
         {
+            Debug.Assert(this.CurrentToken.Kind == SyntaxKind.CatchKeyword);
+
+            var catchToken = this.EatToken();
+
+            CatchDeclarationSyntax decl = null;
+            CatchFilterClauseSyntax filter = null;
+            GreenNode badTokens = null;
+
+            var saveTerm = _termState;
+
+            // following could be the Exception declaration - most likely if we had an open paren - it could also be the "when" filter
+            if (CurrentKind == SyntaxKind.OpenParenToken || (
+                CurrentContextualKind != SyntaxKind.WhenKeyword &&
+                CurrentKind != SyntaxKind.FinallyKeyword &&
+                CurrentKind != SyntaxKind.OpenBraceToken &&
+                CurrentKind != SyntaxKind.EqualsGreaterThanToken))
+            {
+                SyntaxToken openParen = null;
+                SyntaxToken closeParen = null;
+
+                // may or may not have open paren
+                openParen = this.TryEatToken(SyntaxKind.OpenParenToken);
+
+                // should be the Exception declaration ... try parsing it
+                _termState |= TerminatorState.IsEndOfCatchClause;
+
+                SyntaxToken name = null;
+                TypeSyntax type = null;
+
+                // try parsing name and then the type, if we only have the name, then it's acutally a type
+                var typeOrName = TryParseType();
+                if (typeOrName is SimpleNameSyntax simpleName)
+                {
+                    // this could be a name ... so lets check if we are at the type ...
+                    type = TryParseType(allowKeywordName: false);
+
+                    // now the tricky part is that we want to support the following syntaxes (both of which are ambiguous):
+                    // *** the difficulty is to say whether it's a Type or a Variable ***
+                    //     - we simply say that if the name doesn't contain "Exception" ... then it's not an exception type
+                    // 1. specialization on exception type only - allows custom handling of different exception types
+                    //   catch SpecialExcpetion => ...
+                    //   catch AnotherSpecialExcpetion => ...
+                    //   catch Excpetion => ...
+                    // 2. shorthand exeption variable - makes it easy & convenient to handle exception
+                    //   catch e => ...
+
+                    if (type != null)
+                    {
+                        // OK, we have a type following anyway, so no worries
+                        name = simpleName.Identifier;
+                    }
+                    else
+                    {
+                        // check if the name contains "type"
+                        if (simpleName.Identifier?.Text?.ToLowerInvariant()?.Contains("exception") == true)
+                            type = typeOrName;
+                        else
+                            name = simpleName.Identifier;
+                    }
+                }
+
+                if (type == null)
+                {
+                    // we need at least the type ... lets create a fake one ...
+                    type = SyntaxFactory.FakeTypeIdentifier();
+                }
+
+                _termState = saveTerm;
+
+                if (openParen != null)
+                {
+                    // we should have a closing paren!
+                    closeParen = this.EatToken(SyntaxKind.CloseParenToken);
+                }
+                else
+                {
+                    // we allow broken syntax by consuming a close paren if its that
+                    closeParen = this.TryEatToken(SyntaxKind.CloseParenToken);
+                }
+
+                // only create a declaration if there is at least something
+                if (openParen?.Width > 0 || name?.Width > 0 || type?.Width > 0 || closeParen?.Width > 0)
+                {
+                    decl = _syntaxFactory.CatchDeclaration(openParen, name, type, closeParen);
+
+                    // skip tokens until next possible part
+                    badTokens = skipUntilWhenFilter();
+                    decl = AddTrailingSkippedSyntax(decl, badTokens);
+                }
+            }
+
+            // we should be either at the filter part or at the open brace
+            badTokens = skipUntilWhenFilter();
+            catchToken = AddTrailingSkippedSyntax(catchToken, badTokens);
+
+            // parse the filter if we are at the "when" keyword
+            if (CurrentContextualKind == SyntaxKind.WhenKeyword)
+            {
+                SyntaxToken whenKeyword;
+                SyntaxToken openParen = null;
+                SyntaxToken closeParen = null;
+                ExpressionSyntax filterExpression = null;
+
+                whenKeyword = this.EatContextualToken(SyntaxKind.WhenKeyword);
+
+                whenKeyword = CheckFeatureAvailability(whenKeyword, MessageID.IDS_FeatureExceptionFilter);
+                _termState |= TerminatorState.IsEndOfFilterClause;
+
+                openParen = this.TryEatToken(SyntaxKind.OpenParenToken);
+
+                var wasTrailingLambdaAllowed = IsTrailingLambdaAllowed;
+                var wasSimpleExpression = IsSimpleExpression;
+                IsTrailingLambdaAllowed = false;
+                IsSimpleExpression = true;
+                try
+                {
+                    filterExpression = this.ParseExpressionCore();
+                }
+                finally
+                {
+                    IsTrailingLambdaAllowed = wasTrailingLambdaAllowed;
+                    IsSimpleExpression = wasSimpleExpression;
+                }
+
+                _termState = saveTerm;
+
+                if (openParen != null)
+                {
+                    // we should have a closing paren!
+                    closeParen = this.EatToken(SyntaxKind.CloseParenToken);
+                }
+                else
+                {
+                    // we allow broken syntax by consuming a close paren if its that
+                    closeParen = this.TryEatToken(SyntaxKind.CloseParenToken);
+                }
+
+                badTokens = skipUntilCatchBlock();
+                filter = _syntaxFactory.CatchFilterClause(whenKeyword, openParen, filterExpression, closeParen);
+                filter = AddTrailingSkippedSyntax(filter, badTokens);
+            }
+
+            // we should be at the open brace part
+            badTokens = skipUntilCatchBlock();
+            catchToken = AddTrailingSkippedSyntax(catchToken, badTokens);
+
+            BlockSyntax block = null;
+            if (CurrentKind == SyntaxKind.EqualsGreaterThanToken)
+            {
+                var catchBlockSveTerm = _termState;
+                _termState |= TerminatorState.IsEndOfCatchBlock;
+
+                block = ParseArrowExprStatementBlock(simpleExpr: true);
+
+                _termState = catchBlockSveTerm;
+            }
+            else if (CurrentKind == SyntaxKind.OpenBraceToken)
+            {
+                var catchBlockSveTerm = _termState;
+                _termState |= TerminatorState.IsEndOfCatchBlock;
+
+                // must be a brace body
+                block = this.ParsePossiblyAttributedBlock();
+
+                _termState = catchBlockSveTerm;
+            }
+
+            if (block == null)
+            {
+                block = _syntaxFactory.Block(
+                    attributeLists: default,
+                    SyntaxToken.CreateMissing(SyntaxKind.OpenBraceToken, null, null),
+                    default(SyntaxList<StatementSyntax>),
+                    SyntaxToken.CreateMissing(SyntaxKind.CloseBraceToken, null, null)
+                );
+            }
+
+            _termState = saveTerm;
+
+            return _syntaxFactory.CatchClause(catchToken, decl, filter, block);
+
+            GreenNode skipUntilWhenFilter()
+            {
+                // we should be either at the filter part or at the open brace
+                if (CurrentContextualKind != SyntaxKind.WhenKeyword &&
+                    CurrentKind != SyntaxKind.FinallyKeyword &&
+                    CurrentKind != SyntaxKind.OpenBraceToken &&
+                    CurrentKind != SyntaxKind.EqualsGreaterThanToken)
+                {
+                    // skip until we are at either of {, =>, when, finally ...
+                    var badTokensTrivia = SkipBadTokensUntil(
+                        skippedErrorCode: ErrorCode.ERR_UnexpectedToken,
+                        untilPredicate: () =>
+                            CurrentContextualKind == SyntaxKind.WhenClause ||
+                            CurrentKind == SyntaxKind.OpenBraceToken ||
+                            CurrentKind == SyntaxKind.EqualsGreaterThanToken ||
+                            CurrentKind == SyntaxKind.FinallyKeyword ||
+                            IsProbablyStatementEnd()
+                    );
+
+                    return badTokensTrivia;
+                }
+
+                return null;
+            }
+
+            GreenNode skipUntilCatchBlock()
+            {
+                // we should be at the
+                if (CurrentKind != SyntaxKind.OpenBraceToken &&
+                    CurrentKind != SyntaxKind.EqualsGreaterThanToken &&
+                    CurrentKind != SyntaxKind.FinallyKeyword)
+                {
+                    // skip until we are at either of {, =>, finally ...
+                    var badTokensTrivia = SkipBadTokensUntil(
+                        skippedErrorCode: ErrorCode.ERR_UnexpectedToken,
+                        untilPredicate: () =>
+                            CurrentKind == SyntaxKind.OpenBraceToken ||
+                            CurrentKind == SyntaxKind.EqualsGreaterThanToken ||
+                            CurrentKind == SyntaxKind.FinallyKeyword ||
+                            IsProbablyStatementEnd()
+                    );
+
+                    // add the skipped tokens
+                    return badTokensTrivia;
+                }
+
+                return null;
+            }
+        }
+        #endregion
+
+        #region finally
+        private (SyntaxToken, BlockSyntax) ParseFinallyBlock(SyntaxList<AttributeListSyntax> attributes = default)
+        {
+            if (CurrentKind != SyntaxKind.FinallyKeyword) return (null, null);
+
             SyntaxToken finallyToken = null;
             BlockSyntax finallyBlock = null;
-
-            if (this.CurrentToken.Kind != SyntaxKind.FinallyKeyword) return (null, null);
 
             // parse the "finally" token
             finallyToken = this.EatToken(SyntaxKind.FinallyKeyword);
 
-            if (CurrentToken.Kind != SyntaxKind.OpenBraceToken)
+            // we should be at an { or => token to proceed ... otherwise we will just stop and continue
+            if (CurrentKind != SyntaxKind.OpenBraceToken && CurrentKind != SyntaxKind.EqualsGreaterThanToken)
             {
+                // we also allow simple "try DoSomeExpression()" ... which means that if we are at an identifier, then we will try to parse a simple expression
+                if (CurrentKind == SyntaxKind.IdentifierToken)
+                {
+                    var resetPoint = GetResetPoint();
+                    try
+                    {
+                        var exprStatBlock = ParseExprStatementBlock(attributes, simpleExpr: true);
+                        if (!exprStatBlock.ContainsDiagnostics)
+                        {
+                            // accept the block if no errors
+                            finallyBlock = exprStatBlock;
+                            attributes = default;
+                        }
+                        else
+                        {
+                            // undo the expr parsing ... we will skip the syntax and say missing block later ...
+                            Reset(ref resetPoint);
+                        }
+                    }
+                    finally
+                    {
+                        Release(ref resetPoint);
+                    }
+                }
+
                 // skip until the next possible start
                 var badTokensTrivia = SkipBadTokensUntil(
                     skippedErrorCode: ErrorCode.ERR_UnexpectedToken,
-                    untilPredicate: () => 
-                        CurrentToken.Kind == SyntaxKind.OpenBraceToken |
+                    untilPredicate: () =>
+                        CurrentKind == SyntaxKind.OpenBraceToken ||
+                        CurrentKind == SyntaxKind.EqualsGreaterThanToken ||
+                        CurrentKind == SyntaxKind.CatchKeyword ||
+                        CurrentKind == SyntaxKind.FinallyKeyword ||
                         IsProbablyStatementEnd()
                 );
 
                 // add the skipped tokens
-                finallyToken = AddTrailingSkippedSyntax(finallyToken, badTokensTrivia);
-            }
-
-            // parse the {...} block
-            if (CurrentToken.Kind == SyntaxKind.OpenBraceToken)
-            {
-                finallyBlock = this.ParsePossiblyAttributedBlock();
+                if (finallyBlock != null) finallyBlock = AddTrailingSkippedSyntax(finallyBlock, badTokensTrivia);
+                else finallyToken = AddTrailingSkippedSyntax(finallyToken, badTokensTrivia);
             }
 
             if (finallyBlock == null)
-            { 
+            {
+                // parse the =>, {...} block
+                if (CurrentKind == SyntaxKind.EqualsGreaterThanToken)
+                {
+                    var saveTerm = _termState;
+                    _termState |= TerminatorState.IsEndOfTryBlock;
+
+                    finallyBlock = ParseArrowExprStatementBlock(attributes, simpleExpr: true);
+                    attributes = default;
+
+                    _termState = saveTerm;
+                }
+                else if (CurrentKind == SyntaxKind.OpenBraceToken)
+                {
+                    var saveTerm = _termState;
+                    _termState |= TerminatorState.IsEndOfTryBlock;
+
+                    finallyBlock = ParsePossiblyAttributedBlock(attributes);
+                    attributes = default;
+
+                    _termState = saveTerm;
+                }
+            }
+
+            if (finallyBlock == null)
+            {
                 finallyBlock = _syntaxFactory.Block(
-                    attributeLists: default,
+                    attributeLists: attributes,
                     SyntaxToken.CreateMissing(SyntaxKind.OpenBraceToken, null, null),
                     default(SyntaxList<StatementSyntax>),
                     SyntaxToken.CreateMissing(SyntaxKind.CloseBraceToken, null, null)
@@ -9332,143 +9692,14 @@ done:;
 
             return (finallyToken, finallyBlock);
         }
+        #endregion
 
-        private TryStatementSyntax ParseTryStatement(SyntaxList<AttributeListSyntax> attributes)
-        {
-            var isInTry = _isInTry;
-            _isInTry = true;
-
-            var @try = this.EatToken(SyntaxKind.TryKeyword);
-
-            BlockSyntax block;
-            if (@try.IsMissing)
-            {
-                block = _syntaxFactory.Block(
-                    attributeLists: default, this.EatToken(SyntaxKind.OpenBraceToken), default(SyntaxList<StatementSyntax>), this.EatToken(SyntaxKind.CloseBraceToken));
-            }
-            else
-            {
-                var saveTerm = _termState;
-                _termState |= TerminatorState.IsEndOfTryBlock;
-                block = this.ParsePossiblyAttributedBlock();
-                _termState = saveTerm;
-            }
-
-            var catches = default(SyntaxListBuilder<CatchClauseSyntax>);
-            FinallyClauseSyntax @finally = null;
-            try
-            {
-                bool hasEnd = false;
-
-                if (this.CurrentToken.Kind == SyntaxKind.CatchKeyword)
-                {
-                    hasEnd = true;
-                    catches = _pool.Allocate<CatchClauseSyntax>();
-                    while (this.CurrentToken.Kind == SyntaxKind.CatchKeyword)
-                    {
-                        catches.Add(this.ParseCatchClause());
-                    }
-                }
-
-                if (this.CurrentToken.Kind == SyntaxKind.FinallyKeyword)
-                {
-                    hasEnd = true;
-                    var fin = this.EatToken();
-                    var finBlock = this.ParsePossiblyAttributedBlock();
-                    @finally = _syntaxFactory.FinallyClause(fin, finBlock);
-                }
-
-                if (!hasEnd)
-                {
-                    block = this.AddErrorToLastToken(block, ErrorCode.ERR_ExpectedEndTry);
-
-                    // synthesize missing tokens for "finally { }":
-                    @finally = _syntaxFactory.FinallyClause(
-                        SyntaxToken.CreateMissing(SyntaxKind.FinallyKeyword, null, null),
-                        _syntaxFactory.Block(
-                            attributeLists: default,
-                            SyntaxToken.CreateMissing(SyntaxKind.OpenBraceToken, null, null),
-                            default(SyntaxList<StatementSyntax>),
-                            SyntaxToken.CreateMissing(SyntaxKind.CloseBraceToken, null, null)));
-                }
-
-                _isInTry = isInTry;
-
-                return _syntaxFactory.TryStatement(attributes, @try, block, catches, @finally);
-            }
-            finally
-            {
-                if (!catches.IsNull)
-                {
-                    _pool.Free(catches);
-                }
-            }
-        }
-
+        #region helpers
         private bool IsEndOfTryBlock()
         {
             return this.CurrentToken.Kind == SyntaxKind.CloseBraceToken
                 || this.CurrentToken.Kind == SyntaxKind.CatchKeyword
                 || this.CurrentToken.Kind == SyntaxKind.FinallyKeyword;
-        }
-
-        private CatchClauseSyntax ParseCatchClause()
-        {
-            Debug.Assert(this.CurrentToken.Kind == SyntaxKind.CatchKeyword);
-
-            var @catch = this.EatToken();
-
-            CatchDeclarationSyntax decl = null;
-            var saveTerm = _termState;
-
-            if (this.CurrentToken.Kind == SyntaxKind.OpenParenToken)
-            {
-                var openParen = this.EatToken();
-
-                _termState |= TerminatorState.IsEndOfCatchClause;
-                var type = this.ParseType();
-                SyntaxToken name = null;
-                if (this.IsTrueIdentifier())
-                {
-                    name = this.ParseIdentifierToken();
-                }
-
-                _termState = saveTerm;
-
-                var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                decl = _syntaxFactory.CatchDeclaration(openParen, type, name, closeParen);
-            }
-
-            CatchFilterClauseSyntax filter = null;
-
-            var keywordKind = this.CurrentToken.ContextualKind;
-            if (keywordKind == SyntaxKind.WhenKeyword || keywordKind == SyntaxKind.IfKeyword)
-            {
-                var whenKeyword = this.EatContextualToken(SyntaxKind.WhenKeyword);
-                if (keywordKind == SyntaxKind.IfKeyword)
-                {
-                    // The initial design of C# exception filters called for the use of the
-                    // "if" keyword in this position.  We've since changed to "when", but 
-                    // the error recovery experience for early adopters (and for old source
-                    // stored in the symbol server) will be better if we consume "if" as
-                    // though it were "when".
-                    whenKeyword = AddTrailingSkippedSyntax(whenKeyword, EatToken());
-                }
-                whenKeyword = CheckFeatureAvailability(whenKeyword, MessageID.IDS_FeatureExceptionFilter);
-                _termState |= TerminatorState.IsEndOfFilterClause;
-                var openParen = this.EatToken(SyntaxKind.OpenParenToken);
-                var filterExpression = this.ParseExpressionCore();
-
-                _termState = saveTerm;
-                var closeParen = this.EatToken(SyntaxKind.CloseParenToken);
-                filter = _syntaxFactory.CatchFilterClause(whenKeyword, openParen, filterExpression, closeParen);
-            }
-
-            _termState |= TerminatorState.IsEndOfCatchBlock;
-            var block = this.ParsePossiblyAttributedBlock();
-            _termState = saveTerm;
-
-            return _syntaxFactory.CatchClause(@catch, decl, filter, block);
         }
 
         private bool IsEndOfCatchClause()
@@ -9494,6 +9725,9 @@ done:;
                 || this.CurrentToken.Kind == SyntaxKind.CatchKeyword
                 || this.CurrentToken.Kind == SyntaxKind.FinallyKeyword;
         }
+        #endregion
+
+        #endregion
 
         private StatementSyntax ParseCheckedStatement(SyntaxList<AttributeListSyntax> attributes)
         {
@@ -11024,12 +11258,12 @@ tryAgain:
                 semicolon);
         }
 
-        private ExpressionStatementSyntax ParseExpressionStatement(SyntaxList<AttributeListSyntax> attributes)
+        private ExpressionStatementSyntax ParseExpressionStatement(SyntaxList<AttributeListSyntax> attributes, bool semicolonRequired = true)
         {
-            return ParseExpressionStatement(attributes, this.ParseExpressionCore());
+            return ParseExpressionStatement(attributes, this.ParseExpressionCore(), semicolonRequired);
         }
 
-        private ExpressionStatementSyntax ParseExpressionStatement(SyntaxList<AttributeListSyntax> attributes, ExpressionSyntax expression)
+        private ExpressionStatementSyntax ParseExpressionStatement(SyntaxList<AttributeListSyntax> attributes, ExpressionSyntax expression, bool semicolonRequired = true)
         {
             SyntaxToken semicolon;
             if (IsScript && this.CurrentToken.Kind == SyntaxKind.EndOfFileToken)
@@ -11038,7 +11272,6 @@ tryAgain:
             }
             else
             {
-                var semicolonRequired = true;
                 if (expression is InvocationExpressionSyntax invocationExprSyntax && invocationExprSyntax.ArgumentList?.TrailingLambdaBlock != null)
                 {
                     // argument expression with a trailing lambda block doesn't require semicolon

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Blocks.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Blocks.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Contracts;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.Text;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
+{
+    using System.Linq.Expressions;
+    using System.Text;
+    using Microsoft.CodeAnalysis.Syntax.InternalSyntax;
+
+    internal partial class LanguageParser
+    {
+        private BlockSyntax ParseArrowExprStatementBlock(SyntaxList<AttributeListSyntax> attributes = default, bool semicolonRequired = false, bool simpleExpr = true)
+        {
+            var wasSimpleExpression = IsSimpleExpression;
+            IsSimpleExpression = simpleExpr;
+            try
+            {
+                var arrowToken = EatToken(SyntaxKind.EqualsGreaterThanToken);
+
+                var exprStat = ParseExpressionStatement(attributes, semicolonRequired: semicolonRequired);
+
+                // skip the arrow, it's not part of the syntax
+                exprStat = AddLeadingSkippedSyntax(exprStat, arrowToken);
+
+                var block = SyntaxFactory.FakeBlock(
+                    _syntaxFactory,
+                    statements: SyntaxFactory.List<StatementSyntax>(exprStat)
+                );
+
+                return block;
+            }
+            finally
+            {
+                IsSimpleExpression = wasSimpleExpression;
+            }
+        }
+
+        private BlockSyntax ParseExprStatementBlock(SyntaxList<AttributeListSyntax> attributes = default, bool semicolonRequired = false, bool simpleExpr = true)
+        {
+            var wasSimpleExpression = IsSimpleExpression;
+            IsSimpleExpression = simpleExpr;
+            try
+            {
+                var exprStat = ParseExpressionStatement(attributes, semicolonRequired: semicolonRequired);
+
+                return SyntaxFactory.FakeBlock(
+                    _syntaxFactory,
+                    statements: SyntaxFactory.List<StatementSyntax>(exprStat)
+                );
+            }
+            finally
+            {
+                IsSimpleExpression = wasSimpleExpression;
+            }
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Blocks.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Blocks.cs
@@ -46,7 +46,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         private BlockSyntax ParseExprStatementBlock(SyntaxList<AttributeListSyntax> attributes = default, bool semicolonRequired = false, bool simpleExpr = true)
         {
             var wasSimpleExpression = IsSimpleExpression;
+            var didAllowLambdaExpression = AllowLambdaExpression;
             IsSimpleExpression = simpleExpr;
+            AllowLambdaExpression = !simpleExpr;
             try
             {
                 var exprStat = ParseExpressionStatement(attributes, semicolonRequired: semicolonRequired);
@@ -59,6 +61,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             finally
             {
                 IsSimpleExpression = wasSimpleExpression;
+                AllowLambdaExpression = didAllowLambdaExpression;
             }
         }
     }

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -291,6 +291,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
+        protected SyntaxKind CurrentKind => CurrentToken.Kind;
+        protected SyntaxKind CurrentContextualKind => CurrentToken.ContextualKind;
+
         protected bool IsCurrentTokenEndOfFile
         {
             get => CurrentToken.Kind == SyntaxKind.EndOfFileToken;

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.FindToken(int position, bool findInsideTrivia = false, bool findInsideSkippedTrivia = false) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Conversion.IsConditionalExpression.get -> bool
 Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.AddModifiers(params Microsoft.CodeAnalysis.SyntaxToken[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.WithModifiers(Microsoft.CodeAnalysis.SyntaxTokenList modifiers) -> Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax
@@ -56,9 +57,6 @@ Microsoft.CodeAnalysis.CSharp.SyntaxKind.ImportKeyword = 8385 -> Microsoft.CodeA
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LambdaFunctionType = 9034 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.Modifiers.get -> Microsoft.CodeAnalysis.SyntaxTokenList
 abstract Microsoft.CodeAnalysis.CSharp.Syntax.CommonForEachStatementSyntax.EqualsGreaterThanToken.get -> Microsoft.CodeAnalysis.SyntaxToken
-override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ToFullString() -> string
-override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.ToString() -> string
-override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.WriteTo(System.IO.TextWriter writer) -> void
 override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitDefaultConstraint(Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode
 override Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousMethodExpressionSyntax.Modifiers.get -> Microsoft.CodeAnalysis.SyntaxTokenList
 override Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void
@@ -77,6 +75,7 @@ static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AnonymousMethodExpression(Mic
 Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions.WithSyntaxTreeOptionsProvider(Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider provider) -> Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ArgumentList(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax> arguments, Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax trailingLambdaBlock) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ArgumentList(Microsoft.CodeAnalysis.SyntaxToken openParenToken, Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax> arguments, Microsoft.CodeAnalysis.SyntaxToken closeParenToken, Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax trailingLambdaBlock) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.CatchDeclaration(Microsoft.CodeAnalysis.SyntaxToken identifier, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.CatchDeclarationSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.DefaultConstraint() -> Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.DefaultConstraint(Microsoft.CodeAnalysis.SyntaxToken defaultKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.EventFieldDeclaration(Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclarationSyntax declaration = null) -> Microsoft.CodeAnalysis.CSharp.Syntax.EventFieldDeclarationSyntax

--- a/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/BlockSyntax.cs
@@ -15,14 +15,17 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 
         public bool IsInlineBlockStatement()
         {
-            return OpenBraceToken.Width == 0 && CloseBraceToken.Width == 0 && Statements.Count == 1;
+            return OpenBraceToken.Width == 0 && CloseBraceToken.Width == 0 && Statements.Count <= 1;
         }
 
-        public bool TryGetInlineBlockStatement(out StatementSyntax statement)
+        public bool TryGetInlineBlockStatement(out SyntaxNode statement)
         {
             statement = null;
             if (!IsInlineBlockStatement()) return false;
-            statement = Statements[0];
+            if (Statements.Count == 1)
+                statement = Statements[0];
+            else
+                statement = this;
             return true;
         }
     }

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -400,5 +400,19 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 return syntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
             return SyntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
         }
+
+        public static BlockSyntax MissingBlock(
+            ContextAwareSyntax syntaxFactory = null,
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists = default,
+            SyntaxToken openBraceToken = null,
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements = default,
+            SyntaxToken closeBraceToken = null)
+        {
+            openBraceToken ??= SyntaxFactory.MissingToken(SyntaxKind.OpenBraceToken);
+            closeBraceToken ??= SyntaxFactory.MissingToken(SyntaxKind.CloseBraceToken);
+            if (syntaxFactory != null)
+                return syntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
+            return SyntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -389,9 +389,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
         public static BlockSyntax FakeBlock(
             ContextAwareSyntax syntaxFactory = null,
-            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists = default, 
-            SyntaxToken openBraceToken = null, 
-            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements = default, 
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists = default,
+            SyntaxToken openBraceToken = null,
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<StatementSyntax> statements = default,
             SyntaxToken closeBraceToken = null)
         {
             openBraceToken ??= SyntaxFactory.FakeToken(SyntaxKind.OpenBraceToken, "{");

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -2901,14 +2901,14 @@
   </Node>
   <Node Name="CatchDeclarationSyntax" Base="CSharpSyntaxNode">
     <Kind Name="CatchDeclaration"/>
-    <Field Name="OpenParenToken" Type="SyntaxToken">
+    <Field Name="OpenParenToken" Type="SyntaxToken" Optional="true">
       <Kind Name="OpenParenToken"/>
     </Field>
-    <Field Name="Type" Type="TypeSyntax"/>
     <Field Name="Identifier" Type="SyntaxToken" Optional="true">
       <Kind Name="IdentifierToken"/>
     </Field>
-    <Field Name="CloseParenToken" Type="SyntaxToken">
+    <Field Name="Type" Type="TypeSyntax"/>
+    <Field Name="CloseParenToken" Type="SyntaxToken" Optional="true">
       <Kind Name="CloseParenToken"/>
     </Field>
   </Node>
@@ -2917,11 +2917,11 @@
     <Field Name="WhenKeyword" Type="SyntaxToken">
       <Kind Name="WhenKeyword"/>
     </Field>
-    <Field Name="OpenParenToken" Type="SyntaxToken">
+    <Field Name="OpenParenToken" Type="SyntaxToken" Optional="true">
       <Kind Name="OpenParenToken"/>
     </Field>
     <Field Name="FilterExpression" Type="ExpressionSyntax"/>
-    <Field Name="CloseParenToken" Type="SyntaxToken">
+    <Field Name="CloseParenToken" Type="SyntaxToken" Optional="true">
       <Kind Name="CloseParenToken"/>
     </Field>
   </Node>

--- a/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/TryStatementSyntax.cs
@@ -18,6 +18,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return !TryKeyword.IsMissing && TryKeyword.Width == 0 && Parent is BlockSyntax;
         }
     }
+
+    public partial class CatchDeclarationSyntax
+    {
+        public bool HasExplicitType()
+        {
+            var noExplicitType = Type.Kind() == SyntaxKind.IdentifierName && Type.Width == 0;
+            return !noExplicitType;
+        }
+    }
 }
 
 namespace Microsoft.CodeAnalysis.CSharp

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -419,10 +419,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.CatchClause(InternalSyntaxFactory.Token(SyntaxKind.CatchKeyword), null, null, GenerateBlock());
 
         private static Syntax.InternalSyntax.CatchDeclarationSyntax GenerateCatchDeclaration()
-            => InternalSyntaxFactory.CatchDeclaration(InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), null, InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => InternalSyntaxFactory.CatchDeclaration(null, null, GenerateIdentifierName(), null);
 
         private static Syntax.InternalSyntax.CatchFilterClauseSyntax GenerateCatchFilterClause()
-            => InternalSyntaxFactory.CatchFilterClause(InternalSyntaxFactory.Token(SyntaxKind.WhenKeyword), InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => InternalSyntaxFactory.CatchFilterClause(InternalSyntaxFactory.Token(SyntaxKind.WhenKeyword), null, GenerateIdentifierName(), null);
 
         private static Syntax.InternalSyntax.FinallyClauseSyntax GenerateFinallyClause()
             => InternalSyntaxFactory.FinallyClause(InternalSyntaxFactory.Token(SyntaxKind.FinallyKeyword), GenerateBlock());
@@ -2384,10 +2384,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCatchDeclaration();
 
-            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
-            Assert.NotNull(node.Type);
+            Assert.Null(node.OpenParenToken);
             Assert.Null(node.Identifier);
-            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
+            Assert.NotNull(node.Type);
+            Assert.Null(node.CloseParenToken);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -2398,9 +2398,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCatchFilterClause();
 
             Assert.Equal(SyntaxKind.WhenKeyword, node.WhenKeyword.Kind);
-            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
+            Assert.Null(node.OpenParenToken);
             Assert.NotNull(node.FilterExpression);
-            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
+            Assert.Null(node.CloseParenToken);
 
             AttachAndCheckDiagnostics(node);
         }
@@ -9931,10 +9931,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.CatchClause(SyntaxFactory.Token(SyntaxKind.CatchKeyword), default(CatchDeclarationSyntax), default(CatchFilterClauseSyntax), GenerateBlock());
 
         private static CatchDeclarationSyntax GenerateCatchDeclaration()
-            => SyntaxFactory.CatchDeclaration(SyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), default(SyntaxToken), SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => SyntaxFactory.CatchDeclaration(default(SyntaxToken), default(SyntaxToken), GenerateIdentifierName(), default(SyntaxToken));
 
         private static CatchFilterClauseSyntax GenerateCatchFilterClause()
-            => SyntaxFactory.CatchFilterClause(SyntaxFactory.Token(SyntaxKind.WhenKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.CloseParenToken));
+            => SyntaxFactory.CatchFilterClause(SyntaxFactory.Token(SyntaxKind.WhenKeyword), default(SyntaxToken), GenerateIdentifierName(), default(SyntaxToken));
 
         private static FinallyClauseSyntax GenerateFinallyClause()
             => SyntaxFactory.FinallyClause(SyntaxFactory.Token(SyntaxKind.FinallyKeyword), GenerateBlock());
@@ -11896,11 +11896,11 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         {
             var node = GenerateCatchDeclaration();
 
-            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
-            Assert.NotNull(node.Type);
+            Assert.Equal(SyntaxKind.None, node.OpenParenToken.Kind());
             Assert.Equal(SyntaxKind.None, node.Identifier.Kind());
-            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
-            var newNode = node.WithOpenParenToken(node.OpenParenToken).WithType(node.Type).WithIdentifier(node.Identifier).WithCloseParenToken(node.CloseParenToken);
+            Assert.NotNull(node.Type);
+            Assert.Equal(SyntaxKind.None, node.CloseParenToken.Kind());
+            var newNode = node.WithOpenParenToken(node.OpenParenToken).WithIdentifier(node.Identifier).WithType(node.Type).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
         }
 
@@ -11910,9 +11910,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             var node = GenerateCatchFilterClause();
 
             Assert.Equal(SyntaxKind.WhenKeyword, node.WhenKeyword.Kind());
-            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
+            Assert.Equal(SyntaxKind.None, node.OpenParenToken.Kind());
             Assert.NotNull(node.FilterExpression);
-            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
+            Assert.Equal(SyntaxKind.None, node.CloseParenToken.Kind());
             var newNode = node.WithWhenKeyword(node.WhenKeyword).WithOpenParenToken(node.OpenParenToken).WithFilterExpression(node.FilterExpression).WithCloseParenToken(node.CloseParenToken);
             Assert.Equal(node, newNode);
         }

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -9,9 +9,10 @@ Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsy
 Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.AdditionalText file, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.set -> void
+Microsoft.CodeAnalysis.SyntaxNode.FindToken(int position, bool findInsideTrivia = false, bool findInsideSkippedTrivia = false) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxNode.GetLastToken(bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false, System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate = null) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxNode.HasErrors.get -> bool
-Microsoft.CodeAnalysis.SyntaxNodeOrToken.FullSpanInternal.get -> Microsoft.CodeAnalysis.Text.TextSpan
+Microsoft.CodeAnalysis.SyntaxNodeOrToken.TokenIndex.get -> int
 Microsoft.CodeAnalysis.SyntaxToken.FindNextToken(System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
 Microsoft.CodeAnalysis.SyntaxToken.FindPreviousToken(System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
 Microsoft.CodeAnalysis.SyntaxToken.GetFirstTokenOnLine(bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNavigator.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CodeAnalysis
 
         internal static Func<SyntaxToken, bool> GetPredicateFunction(bool includeZeroWidth)
         {
-            return includeZeroWidth ? SyntaxToken.Any : SyntaxToken.NonZeroWidthOrFake;
+            return includeZeroWidth ? SyntaxToken.Any : SyntaxToken.NonZeroWidth;
         }
 
         private static bool Matches(Func<SyntaxToken, bool>? predicate, SyntaxToken token)

--- a/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxNodeOrToken.cs
@@ -131,6 +131,8 @@ namespace Microsoft.CodeAnalysis
 
         internal int Position => _position;
 
+        public int TokenIndex => _tokenIndex;
+
         /// <summary>
         /// Determines whether this <see cref="SyntaxNodeOrToken"/> is wrapping a token.
         /// </summary>

--- a/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
+++ b/src/Workspaces/CSharp/Portable/CodeGeneration/CSharpSyntaxGenerator.cs
@@ -3457,7 +3457,7 @@ namespace Microsoft.CodeAnalysis.CSharp.CodeGeneration
         public override SyntaxNode CatchClause(SyntaxNode type, string name, IEnumerable<SyntaxNode> statements)
         {
             return SyntaxFactory.CatchClause(
-                SyntaxFactory.CatchDeclaration((TypeSyntax)type, name.ToIdentifierToken()),
+                SyntaxFactory.CatchDeclaration(name.ToIdentifierToken(), (TypeSyntax)type),
                 filter: null,
                 block: CreateBlock(statements));
         }


### PR DESCRIPTION
Updates syntax for try/catch/finally blocks and method declarations to allow shorter syntax and also using the postfix type declaration style for declarations.

Enables syntax like:
```
// evil "do something" and silently continue on exceptions
try DoSomething()

// try catch without braces
try DoSomething()
catch LogError()
finally DoCleanup()

// try catch with arrow syntax
try => DoSomething()
catch => DoSomething()
finally => DoCleanup()

// try catch with declaration
try DoSomething()
catch MyExceptionType1 => LogError() // MyExceptionType1 is an exception type
catch ex MyExceptionType2 => LogError() // local "ex" with MyExceptionType2 as exception type
catch e => LogError() // local "e" with Exception as exception type
catch LogError() // anything else that is remaining

// try with a finally block
try DoSomething
finally {
  DoCleanup1()
  DoCleanup2()
}
```