### PR TITLE
Feature/this constructor syntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -151,7 +151,7 @@ base_method_declaration
   ;
 
 constructor_declaration
-  : attribute_list* modifier* identifier_token parameter_list constructor_initializer? (block | (arrow_expression_clause ';'))
+  : attribute_list* modifier* (identifier_token | 'this') parameter_list constructor_initializer? (block | (arrow_expression_clause ';'))
   ;
 
 parameter_list
@@ -191,7 +191,7 @@ destructor_declaration
   ;
 
 method_declaration
-  : attribute_list* modifier* explicit_interface_specifier? identifier_token type_parameter_list? parameter_list type type_parameter_constraint_clause* (block | (arrow_expression_clause ';'))
+  : attribute_list* modifier* explicit_interface_specifier? (identifier_token | 'this') type_parameter_list? parameter_list type type_parameter_constraint_clause* (block | (arrow_expression_clause ';'))
   ;
 
 explicit_interface_specifier

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -37682,7 +37682,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
 #if DEBUG
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
-            if (identifier.Kind != SyntaxKind.IdentifierToken) throw new ArgumentException(nameof(identifier));
+            switch (identifier.Kind)
+            {
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.ThisKeyword: break;
+                default: throw new ArgumentException(nameof(identifier));
+            }
             if (parameterList == null) throw new ArgumentNullException(nameof(parameterList));
             if (returnType == null) throw new ArgumentNullException(nameof(returnType));
             if (semicolonToken != null)
@@ -37780,7 +37785,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
 #if DEBUG
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
-            if (identifier.Kind != SyntaxKind.IdentifierToken) throw new ArgumentException(nameof(identifier));
+            switch (identifier.Kind)
+            {
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.ThisKeyword: break;
+                default: throw new ArgumentException(nameof(identifier));
+            }
             if (parameterList == null) throw new ArgumentNullException(nameof(parameterList));
             if (semicolonToken != null)
             {
@@ -42573,7 +42583,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
 #if DEBUG
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
-            if (identifier.Kind != SyntaxKind.IdentifierToken) throw new ArgumentException(nameof(identifier));
+            switch (identifier.Kind)
+            {
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.ThisKeyword: break;
+                default: throw new ArgumentException(nameof(identifier));
+            }
             if (parameterList == null) throw new ArgumentNullException(nameof(parameterList));
             if (returnType == null) throw new ArgumentNullException(nameof(returnType));
             if (semicolonToken != null)
@@ -42671,7 +42686,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         {
 #if DEBUG
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
-            if (identifier.Kind != SyntaxKind.IdentifierToken) throw new ArgumentException(nameof(identifier));
+            switch (identifier.Kind)
+            {
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.ThisKeyword: break;
+                default: throw new ArgumentException(nameof(identifier));
+            }
             if (parameterList == null) throw new ArgumentNullException(nameof(parameterList));
             if (semicolonToken != null)
             {

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -5306,7 +5306,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Creates a new MethodDeclarationSyntax instance.</summary>
         public static MethodDeclarationSyntax MethodDeclaration(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, ExplicitInterfaceSpecifierSyntax? explicitInterfaceSpecifier, SyntaxToken identifier, TypeParameterListSyntax? typeParameterList, ParameterListSyntax parameterList, TypeSyntax returnType, SyntaxList<TypeParameterConstraintClauseSyntax> constraintClauses, BlockSyntax? body, ArrowExpressionClauseSyntax? expressionBody, SyntaxToken semicolonToken)
         {
-            if (identifier.Kind() != SyntaxKind.IdentifierToken) throw new ArgumentException(nameof(identifier));
+            switch (identifier.Kind())
+            {
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.ThisKeyword: break;
+                default: throw new ArgumentException(nameof(identifier));
+            }
             if (parameterList == null) throw new ArgumentNullException(nameof(parameterList));
             if (returnType == null) throw new ArgumentNullException(nameof(returnType));
             switch (semicolonToken.Kind())
@@ -5325,10 +5330,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Creates a new MethodDeclarationSyntax instance.</summary>
         public static MethodDeclarationSyntax MethodDeclaration(SyntaxToken identifier, TypeSyntax returnType)
             => SyntaxFactory.MethodDeclaration(default, default(SyntaxTokenList), default, identifier, default, SyntaxFactory.ParameterList(), returnType, default, default, default, default);
-
-        /// <summary>Creates a new MethodDeclarationSyntax instance.</summary>
-        public static MethodDeclarationSyntax MethodDeclaration(string identifier, TypeSyntax returnType)
-            => SyntaxFactory.MethodDeclaration(default, default(SyntaxTokenList), default, SyntaxFactory.Identifier(identifier), default, SyntaxFactory.ParameterList(), returnType, default, default, default, default);
 
         /// <summary>Creates a new OperatorDeclarationSyntax instance.</summary>
         public static OperatorDeclarationSyntax OperatorDeclaration(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, TypeSyntax returnType, SyntaxToken operatorKeyword, SyntaxToken operatorToken, ParameterListSyntax parameterList, BlockSyntax? body, ArrowExpressionClauseSyntax? expressionBody, SyntaxToken semicolonToken)
@@ -5412,7 +5413,12 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Creates a new ConstructorDeclarationSyntax instance.</summary>
         public static ConstructorDeclarationSyntax ConstructorDeclaration(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken identifier, ParameterListSyntax parameterList, ConstructorInitializerSyntax? initializer, BlockSyntax? body, ArrowExpressionClauseSyntax? expressionBody, SyntaxToken semicolonToken)
         {
-            if (identifier.Kind() != SyntaxKind.IdentifierToken) throw new ArgumentException(nameof(identifier));
+            switch (identifier.Kind())
+            {
+                case SyntaxKind.IdentifierToken:
+                case SyntaxKind.ThisKeyword: break;
+                default: throw new ArgumentException(nameof(identifier));
+            }
             if (parameterList == null) throw new ArgumentNullException(nameof(parameterList));
             switch (semicolonToken.Kind())
             {
@@ -5430,10 +5436,6 @@ namespace Microsoft.CodeAnalysis.CSharp
         /// <summary>Creates a new ConstructorDeclarationSyntax instance.</summary>
         public static ConstructorDeclarationSyntax ConstructorDeclaration(SyntaxToken identifier)
             => SyntaxFactory.ConstructorDeclaration(default, default(SyntaxTokenList), identifier, SyntaxFactory.ParameterList(), default, default, default, default);
-
-        /// <summary>Creates a new ConstructorDeclarationSyntax instance.</summary>
-        public static ConstructorDeclarationSyntax ConstructorDeclaration(string identifier)
-            => SyntaxFactory.ConstructorDeclaration(default, default(SyntaxTokenList), SyntaxFactory.Identifier(identifier), SyntaxFactory.ParameterList(), default, default, default, default);
 
         /// <summary>Creates a new ConstructorInitializerSyntax instance.</summary>
         public static ConstructorInitializerSyntax ConstructorInitializer(SyntaxKind kind, SyntaxToken colonToken, SyntaxToken thisOrBaseKeyword, ArgumentListSyntax argumentList)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -2265,7 +2265,7 @@ tryAgain:
                 MemberDeclarationSyntax result;
 
                 // Check for constructor form
-                if (this.CurrentToken.Kind == SyntaxKind.IdentifierToken && this.PeekToken(1).Kind == SyntaxKind.OpenParenToken)
+                if ((CurrentKind == SyntaxKind.IdentifierToken || CurrentKind == SyntaxKind.ThisKeyword) && this.PeekToken(1).Kind == SyntaxKind.OpenParenToken)
                 {
                     // Script: 
                     // Constructor definitions are not allowed. We parse them as method calls with semicolon missing error:
@@ -2466,6 +2466,12 @@ parse_member_name:;
 
                     // check availability of readonly members feature for indexers, properties and methods
                     CheckForVersionSpecificModifiers(modifiers, SyntaxKind.ReadOnlyKeyword, MessageID.IDS_FeatureReadOnlyMembers);
+
+                    // check for "this()" constructor form
+                    if (CurrentKind == SyntaxKind.ThisKeyword && this.PeekToken(1).Kind == SyntaxKind.OpenParenToken && typeParameterListOpt == null)
+                    {
+                        return ParseConstructorDeclaration(attributes, modifiers);
+                    }
 
                     if (TryParseIndexerOrPropertyDeclaration(attributes, modifiers, explicitInterfaceOpt, identifierOrThisOpt, typeParameterListOpt, out result))
                     {
@@ -2822,9 +2828,9 @@ parse_member_name:;
                 this.ParseModifiers(modifiers, forAccessors: false);
 
                 // Check for constructor form
-                if (this.CurrentToken.Kind == SyntaxKind.IdentifierToken && this.PeekToken(1).Kind == SyntaxKind.OpenParenToken)
+                if ((CurrentKind == SyntaxKind.IdentifierToken || CurrentKind == SyntaxKind.ThisKeyword) && this.PeekToken(1).Kind == SyntaxKind.OpenParenToken)
                 {
-                    if (parentName == null || parentName.Text == this.CurrentToken.Text)
+                    if (parentName == null || parentName.Text == this.CurrentToken.Text || CurrentKind == SyntaxKind.ThisKeyword)
                     {
                         return this.ParseConstructorDeclaration(attributes, modifiers);
                     }
@@ -3078,7 +3084,7 @@ parse_member_name:;
         private ConstructorDeclarationSyntax ParseConstructorDeclaration(
             SyntaxList<AttributeListSyntax> attributes, SyntaxListBuilder modifiers)
         {
-            var name = this.ParseIdentifierToken();
+            SyntaxToken name = TryEatToken(SyntaxKind.ThisKeyword) ?? this.ParseIdentifierToken();
             var saveTerm = _termState;
             _termState |= TerminatorState.IsEndOfMethodSignature;
             try

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -3738,7 +3738,7 @@ parse_member_name:;
                     finally
                     {
                         // restore the parse state if didn't parse the accessor list
-                        if(!parsedAccessorList) Reset(ref resetPoint);
+                        if (!parsedAccessorList) Reset(ref resetPoint);
                         Release(ref resetPoint);
                     }
                 }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceConstructorSymbol.cs
@@ -37,7 +37,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             var declarationModifiers = this.MakeModifiers(syntax.Modifiers, methodKind, hasBody, location, diagnostics, out modifierErrors);
             this.MakeFlags(methodKind, declarationModifiers, returnsVoid: true, isExtensionMethod: false);
 
-            if (syntax.Identifier.ValueText != containingType.Name)
+            if (syntax.Identifier.ValueText != containingType.Name && !syntax.Identifier.IsKind(SyntaxKind.ThisKeyword))
             {
                 // This is probably a method declaration with the type missing.
                 diagnostics.Add(ErrorCode.ERR_MemberNeedsType, location);

--- a/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/SourceMemberContainerSymbol.cs
@@ -1679,10 +1679,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
             // If method1 is a constructor only because its return type is missing, then
             // we've already produced a diagnostic for the missing return type and we suppress the
             // diagnostic about duplicate signature.
-            if (method1.MethodKind == MethodKind.Constructor &&
-                ((ConstructorDeclarationSyntax)method1.SyntaxRef.GetSyntax()).Identifier.ValueText != this.Name)
+            if (method1.MethodKind == MethodKind.Constructor)
             {
-                return;
+                var identifier = ((ConstructorDeclarationSyntax)method1.SyntaxRef.GetSyntax()).Identifier;
+                if (identifier.ValueText != this.Name && !identifier.IsKind(SyntaxKind.ThisKeyword))
+                    return;
             }
 
             Debug.Assert(method1.ParameterCount == method2.ParameterCount);

--- a/src/Compilers/CSharp/Portable/Syntax/IndexerDeclarationSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/IndexerDeclarationSyntax.cs
@@ -28,6 +28,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         {
             return this.WithSemicolonToken(semicolon);
         }
+
+        public bool HasExplicitReturnType()
+        {
+            var noExplicitReturnType = Type.Kind() == SyntaxKind.IdentifierName && Type.Width == 0;
+            return !noExplicitReturnType;
+        }
     }
 }
 

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -3666,6 +3666,7 @@
         <summary>Gets the identifier.</summary>
       </PropertyComment>
       <Kind Name="IdentifierToken"/>
+      <Kind Name="ThisKeyword"/>
     </Field>
     <Field Name="TypeParameterList" Type="TypeParameterListSyntax" Optional="true"/>
     <Field Name="ParameterList" Type="ParameterListSyntax" Override="true"/>
@@ -3805,6 +3806,7 @@
         <summary>Gets the identifier.</summary>
       </PropertyComment>
       <Kind Name="IdentifierToken"/>
+      <Kind Name="ThisKeyword"/>
     </Field>
     <Field Name="ParameterList" Type="ParameterListSyntax" Override="true"/>
     <Field Name="Initializer" Type="ConstructorInitializerSyntax" Optional="true"/>

--- a/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Syntax/SyntaxListTests.cs
@@ -223,7 +223,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
         public void AddEmptySyntaxList()
         {
             var attributes = new AttributeListSyntax[0];
-            var newMethodDeclaration = SyntaxFactory.MethodDeclaration("M", SyntaxFactory.ParseTypeName("void"));
+            var newMethodDeclaration = SyntaxFactory.MethodDeclaration(SyntaxFactory.Identifier("M"), SyntaxFactory.ParseTypeName("void"));
             newMethodDeclaration.AddAttributeLists(attributes);
         }
 


### PR DESCRIPTION
Adds shorthand constructor to allow easier copy and paste and quicker to write.

Enables the following syntax:

```
class MyClassWithVeryLongNameThatNoOneWantsToType {
  // standard constructor declaration
  public MyClassWithVeryLongNameThatNoOneWantsToType() {}

  // shorthand constructor declarations
  public this() : this("ref to other constructor") {}
  public this(arg string) {}
}
```