### PR TITLE
Feature/if else syntax

### DIFF
--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -486,7 +486,7 @@ goto_statement
   ;
 
 if_statement
-  : attribute_list* 'if' '(' expression ')' statement else_clause?
+  : attribute_list* 'if' '('? expression ')'? statement else_clause?
   ;
 
 else_clause

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -16623,13 +16623,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
     {
         internal readonly GreenNode? attributeLists;
         internal readonly SyntaxToken ifKeyword;
-        internal readonly SyntaxToken openParenToken;
+        internal readonly SyntaxToken? openParenToken;
         internal readonly ExpressionSyntax condition;
-        internal readonly SyntaxToken closeParenToken;
+        internal readonly SyntaxToken? closeParenToken;
         internal readonly StatementSyntax statement;
         internal readonly ElseClauseSyntax? @else;
 
-        internal IfStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal IfStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken ifKeyword, SyntaxToken? openParenToken, ExpressionSyntax condition, SyntaxToken? closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
             this.SlotCount = 7;
@@ -16640,12 +16640,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(ifKeyword);
             this.ifKeyword = ifKeyword;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             this.AdjustFlagsAndWidth(condition);
             this.condition = condition;
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
             this.AdjustFlagsAndWidth(statement);
             this.statement = statement;
             if (@else != null)
@@ -16655,7 +16661,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        internal IfStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else, SyntaxFactoryContext context)
+        internal IfStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken ifKeyword, SyntaxToken? openParenToken, ExpressionSyntax condition, SyntaxToken? closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
@@ -16667,12 +16673,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(ifKeyword);
             this.ifKeyword = ifKeyword;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             this.AdjustFlagsAndWidth(condition);
             this.condition = condition;
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
             this.AdjustFlagsAndWidth(statement);
             this.statement = statement;
             if (@else != null)
@@ -16682,7 +16694,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        internal IfStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
+        internal IfStatementSyntax(SyntaxKind kind, GreenNode? attributeLists, SyntaxToken ifKeyword, SyntaxToken? openParenToken, ExpressionSyntax condition, SyntaxToken? closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
           : base(kind)
         {
             this.SlotCount = 7;
@@ -16693,12 +16705,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(ifKeyword);
             this.ifKeyword = ifKeyword;
-            this.AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            if (openParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             this.AdjustFlagsAndWidth(condition);
             this.condition = condition;
-            this.AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            if (closeParenToken != null)
+            {
+                this.AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
             this.AdjustFlagsAndWidth(statement);
             this.statement = statement;
             if (@else != null)
@@ -16716,7 +16734,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         /// <summary>
         /// Gets a SyntaxToken that represents the open parenthesis before the if statement's condition expression.
         /// </summary>
-        public SyntaxToken OpenParenToken => this.openParenToken;
+        public SyntaxToken? OpenParenToken => this.openParenToken;
         /// <summary>
         /// Gets an ExpressionSyntax that represents the condition of the if statement.
         /// </summary>
@@ -16724,7 +16742,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         /// <summary>
         /// Gets a SyntaxToken that represents the close parenthesis after the if statement's condition expression.
         /// </summary>
-        public SyntaxToken CloseParenToken => this.closeParenToken;
+        public SyntaxToken? CloseParenToken => this.closeParenToken;
         /// <summary>
         /// Gets a StatementSyntax the represents the statement to be executed when the condition is true.
         /// </summary>
@@ -16788,15 +16806,21 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             var ifKeyword = (SyntaxToken)reader.ReadValue();
             AdjustFlagsAndWidth(ifKeyword);
             this.ifKeyword = ifKeyword;
-            var openParenToken = (SyntaxToken)reader.ReadValue();
-            AdjustFlagsAndWidth(openParenToken);
-            this.openParenToken = openParenToken;
+            var openParenToken = (SyntaxToken?)reader.ReadValue();
+            if (openParenToken != null)
+            {
+                AdjustFlagsAndWidth(openParenToken);
+                this.openParenToken = openParenToken;
+            }
             var condition = (ExpressionSyntax)reader.ReadValue();
             AdjustFlagsAndWidth(condition);
             this.condition = condition;
-            var closeParenToken = (SyntaxToken)reader.ReadValue();
-            AdjustFlagsAndWidth(closeParenToken);
-            this.closeParenToken = closeParenToken;
+            var closeParenToken = (SyntaxToken?)reader.ReadValue();
+            if (closeParenToken != null)
+            {
+                AdjustFlagsAndWidth(closeParenToken);
+                this.closeParenToken = closeParenToken;
+            }
             var statement = (StatementSyntax)reader.ReadValue();
             AdjustFlagsAndWidth(statement);
             this.statement = statement;
@@ -36741,16 +36765,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new LockStatementSyntax(SyntaxKind.LockStatement, attributeLists.Node, lockKeyword, openParenToken, expression, closeParenToken, statement, this.context);
         }
 
-        public IfStatementSyntax IfStatement(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
+        public IfStatementSyntax IfStatement(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken ifKeyword, SyntaxToken? openParenToken, ExpressionSyntax condition, SyntaxToken? closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
         {
 #if DEBUG
             if (ifKeyword == null) throw new ArgumentNullException(nameof(ifKeyword));
             if (ifKeyword.Kind != SyntaxKind.IfKeyword) throw new ArgumentException(nameof(ifKeyword));
-            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
-            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (openParenToken != null)
+            {
+                switch (openParenToken.Kind)
+                {
+                    case SyntaxKind.OpenParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(openParenToken));
+                }
+            }
             if (condition == null) throw new ArgumentNullException(nameof(condition));
-            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
-            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            if (closeParenToken != null)
+            {
+                switch (closeParenToken.Kind)
+                {
+                    case SyntaxKind.CloseParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(closeParenToken));
+                }
+            }
             if (statement == null) throw new ArgumentNullException(nameof(statement));
 #endif
 
@@ -41642,16 +41680,30 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return new LockStatementSyntax(SyntaxKind.LockStatement, attributeLists.Node, lockKeyword, openParenToken, expression, closeParenToken, statement);
         }
 
-        public static IfStatementSyntax IfStatement(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
+        public static IfStatementSyntax IfStatement(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken ifKeyword, SyntaxToken? openParenToken, ExpressionSyntax condition, SyntaxToken? closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
         {
 #if DEBUG
             if (ifKeyword == null) throw new ArgumentNullException(nameof(ifKeyword));
             if (ifKeyword.Kind != SyntaxKind.IfKeyword) throw new ArgumentException(nameof(ifKeyword));
-            if (openParenToken == null) throw new ArgumentNullException(nameof(openParenToken));
-            if (openParenToken.Kind != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            if (openParenToken != null)
+            {
+                switch (openParenToken.Kind)
+                {
+                    case SyntaxKind.OpenParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(openParenToken));
+                }
+            }
             if (condition == null) throw new ArgumentNullException(nameof(condition));
-            if (closeParenToken == null) throw new ArgumentNullException(nameof(closeParenToken));
-            if (closeParenToken.Kind != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            if (closeParenToken != null)
+            {
+                switch (closeParenToken.Kind)
+                {
+                    case SyntaxKind.CloseParenToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(closeParenToken));
+                }
+            }
             if (statement == null) throw new ArgumentNullException(nameof(statement));
 #endif
 

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -4496,20 +4496,30 @@ namespace Microsoft.CodeAnalysis.CSharp
         public static IfStatementSyntax IfStatement(SyntaxList<AttributeListSyntax> attributeLists, SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax? @else)
         {
             if (ifKeyword.Kind() != SyntaxKind.IfKeyword) throw new ArgumentException(nameof(ifKeyword));
-            if (openParenToken.Kind() != SyntaxKind.OpenParenToken) throw new ArgumentException(nameof(openParenToken));
+            switch (openParenToken.Kind())
+            {
+                case SyntaxKind.OpenParenToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(openParenToken));
+            }
             if (condition == null) throw new ArgumentNullException(nameof(condition));
-            if (closeParenToken.Kind() != SyntaxKind.CloseParenToken) throw new ArgumentException(nameof(closeParenToken));
+            switch (closeParenToken.Kind())
+            {
+                case SyntaxKind.CloseParenToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(closeParenToken));
+            }
             if (statement == null) throw new ArgumentNullException(nameof(statement));
-            return (IfStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.IfStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)ifKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken)openParenToken.Node!, (Syntax.InternalSyntax.ExpressionSyntax)condition.Green, (Syntax.InternalSyntax.SyntaxToken)closeParenToken.Node!, (Syntax.InternalSyntax.StatementSyntax)statement.Green, @else == null ? null : (Syntax.InternalSyntax.ElseClauseSyntax)@else.Green).CreateRed();
+            return (IfStatementSyntax)Syntax.InternalSyntax.SyntaxFactory.IfStatement(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), (Syntax.InternalSyntax.SyntaxToken)ifKeyword.Node!, (Syntax.InternalSyntax.SyntaxToken?)openParenToken.Node, (Syntax.InternalSyntax.ExpressionSyntax)condition.Green, (Syntax.InternalSyntax.SyntaxToken?)closeParenToken.Node, (Syntax.InternalSyntax.StatementSyntax)statement.Green, @else == null ? null : (Syntax.InternalSyntax.ElseClauseSyntax)@else.Green).CreateRed();
         }
 
         /// <summary>Creates a new IfStatementSyntax instance.</summary>
         public static IfStatementSyntax IfStatement(SyntaxList<AttributeListSyntax> attributeLists, ExpressionSyntax condition, StatementSyntax statement, ElseClauseSyntax? @else)
-            => SyntaxFactory.IfStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.IfKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), condition, SyntaxFactory.Token(SyntaxKind.CloseParenToken), statement, @else);
+            => SyntaxFactory.IfStatement(attributeLists, SyntaxFactory.Token(SyntaxKind.IfKeyword), default, condition, default, statement, @else);
 
         /// <summary>Creates a new IfStatementSyntax instance.</summary>
         public static IfStatementSyntax IfStatement(ExpressionSyntax condition, StatementSyntax statement)
-            => SyntaxFactory.IfStatement(default, SyntaxFactory.Token(SyntaxKind.IfKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), condition, SyntaxFactory.Token(SyntaxKind.CloseParenToken), statement, default);
+            => SyntaxFactory.IfStatement(default, SyntaxFactory.Token(SyntaxKind.IfKeyword), default, condition, default, statement, default);
 
         /// <summary>Creates a new ElseClauseSyntax instance.</summary>
         public static ElseClauseSyntax ElseClause(SyntaxToken elseKeyword, StatementSyntax statement)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -7145,7 +7145,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         /// <summary>
         /// Gets a SyntaxToken that represents the open parenthesis before the if statement's condition expression.
         /// </summary>
-        public SyntaxToken OpenParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.IfStatementSyntax)this.Green).openParenToken, GetChildPosition(2), GetChildIndex(2));
+        public SyntaxToken OpenParenToken
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.IfStatementSyntax)this.Green).openParenToken;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(2), GetChildIndex(2)) : default;
+            }
+        }
 
         /// <summary>
         /// Gets an ExpressionSyntax that represents the condition of the if statement.
@@ -7155,7 +7162,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         /// <summary>
         /// Gets a SyntaxToken that represents the close parenthesis after the if statement's condition expression.
         /// </summary>
-        public SyntaxToken CloseParenToken => new SyntaxToken(this, ((Syntax.InternalSyntax.IfStatementSyntax)this.Green).closeParenToken, GetChildPosition(4), GetChildIndex(4));
+        public SyntaxToken CloseParenToken
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.IfStatementSyntax)this.Green).closeParenToken;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(4), GetChildIndex(4)) : default;
+            }
+        }
 
         /// <summary>
         /// Gets a StatementSyntax the represents the statement to be executed when the condition is true.

--- a/src/Compilers/CSharp/Portable/Parser/Blender.Cursor.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Blender.Cursor.cs
@@ -78,8 +78,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 if (_leadingTriviaToken != null)
                 {
                     // we are at the leading trivia, so just move to the token next - but, since this is a reused token, clear the trivia from it... we have already returned it as tokens...
-                    var newLeadingTrivia = _currentNodeOrToken.GetLeadingTrivia().Where(t => !t.IsSkippedTokensTrivia);
-                    var actualTokenOrNode = _currentNodeOrToken.WithLeadingTrivia(newLeadingTrivia);
+                    var newLeadingTrivia = _currentNodeOrToken.GetLeadingTriviaExceptSkippedTokens();
+                    var actualTokenOrNode = _currentNodeOrToken.WithLeadingTrivia(newLeadingTrivia, preservePosition: true);
                     return new Cursor(actualTokenOrNode, _indexInParent);
                 }
 
@@ -186,7 +186,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             {
                 if (child.IsToken && child.HasLeadingTrivia)
                 {
-                    var skippedTriviaNode = child.GetLeadingTrivia().LastOrDefault(t => t.IsSkippedTokensTrivia);
+                    var skippedTriviaNode = child.GetLeadingTriviaSkippedTokens().LastOrDefault();
                     if (skippedTriviaNode.Width > 0)
                     {
                         var lastTriviaToken = skippedTriviaNode.RequiredUnderlyingNode.GetLastNonZeroWidthTerminal();

--- a/src/Compilers/CSharp/Portable/Parser/Blender.Reader.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Blender.Reader.cs
@@ -267,6 +267,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                     return false;
                 }
 
+                if (nodeOrToken.IsToken && nodeOrToken.HasLeadingTriviaSkippedTokens)
+                {
+                    return false;
+                }
+
                 if (!nodeOrToken.ContainsDirectives)
                 {
                     return true;

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -352,6 +352,36 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
+        protected bool IsCurrentLineIndentedRelativeTo(SyntaxToken otherToken)
+        {
+            var i = 0;
+
+            // find the closest newline, so we can calculate the "current line indentation level"
+            var currentLineIndent = GetLineIndent(ref i);
+            if (currentLineIndent == null) return false;
+
+            // now find the next closest newline before the other token
+            var otherTokenIndex = FindPrevTokenIndex(otherToken);
+            if (otherTokenIndex == 0) return true;
+
+            var otherTokenLineIndent = GetLineIndent(ref otherTokenIndex);
+            return (currentLineIndent ?? 0) > (otherTokenLineIndent ?? 0);
+        }
+
+        private int FindPrevTokenIndex(SyntaxToken token)
+        {
+            var i = 0;
+
+            while (true)
+            {
+                var t = PeekPrevToken(i);
+                if (t == null || t == token) break;
+                ++i;
+            }
+
+            return i;
+        }
+
         private int? GetLineIndent(ref int i)
         {
             int? indent = null;

--- a/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/InternalSyntax/SyntaxFactory.cs
@@ -414,5 +414,23 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 return syntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
             return SyntaxFactory.Block(attributeLists, openBraceToken, statements, closeBraceToken);
         }
+
+        public static EmptyStatementSyntax EmptyStatement(SyntaxToken semicolonToken = null)
+        {
+            Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists = default;
+            semicolonToken ??= SyntaxFactory.FakeToken(SyntaxKind.SemicolonToken);
+
+            int hash;
+            var cached = SyntaxNodeCache.TryGetNode((int)SyntaxKind.EmptyStatement, attributeLists.Node, semicolonToken, out hash);
+            if (cached != null) return (EmptyStatementSyntax)cached;
+
+            var result = new EmptyStatementSyntax(SyntaxKind.EmptyStatement, attributeLists.Node, semicolonToken);
+            if (hash >= 0)
+            {
+                SyntaxNodeCache.AddNode(result, hash);
+            }
+
+            return result;
+        }
     }
 }

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -2620,7 +2620,7 @@
         </summary>
       </PropertyComment>
     </Field>
-    <Field Name="OpenParenToken" Type="SyntaxToken">
+    <Field Name="OpenParenToken" Type="SyntaxToken" Optional="true">
       <Kind Name="OpenParenToken"/>
       <PropertyComment>
         <summary>
@@ -2635,7 +2635,7 @@
         </summary>
       </PropertyComment>
     </Field>
-    <Field Name="CloseParenToken" Type="SyntaxToken">
+    <Field Name="CloseParenToken" Type="SyntaxToken" Optional="true">
       <Kind Name="CloseParenToken"/>
       <PropertyComment>
         <summary>

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -386,7 +386,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.LockStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.LockKeyword), InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken), GenerateBlock());
 
         private static Syntax.InternalSyntax.IfStatementSyntax GenerateIfStatement()
-            => InternalSyntaxFactory.IfStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.IfKeyword), InternalSyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), InternalSyntaxFactory.Token(SyntaxKind.CloseParenToken), GenerateBlock(), null);
+            => InternalSyntaxFactory.IfStatement(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.IfKeyword), null, GenerateIdentifierName(), null, GenerateBlock(), null);
 
         private static Syntax.InternalSyntax.ElseClauseSyntax GenerateElseClause()
             => InternalSyntaxFactory.ElseClause(InternalSyntaxFactory.Token(SyntaxKind.ElseKeyword), GenerateBlock());
@@ -2241,9 +2241,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.IfKeyword, node.IfKeyword.Kind);
-            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind);
+            Assert.Null(node.OpenParenToken);
             Assert.NotNull(node.Condition);
-            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind);
+            Assert.Null(node.CloseParenToken);
             Assert.NotNull(node.Statement);
             Assert.Null(node.Else);
 
@@ -9898,7 +9898,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.LockStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.LockKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.CloseParenToken), GenerateBlock());
 
         private static IfStatementSyntax GenerateIfStatement()
-            => SyntaxFactory.IfStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.IfKeyword), SyntaxFactory.Token(SyntaxKind.OpenParenToken), GenerateIdentifierName(), SyntaxFactory.Token(SyntaxKind.CloseParenToken), GenerateBlock(), default(ElseClauseSyntax));
+            => SyntaxFactory.IfStatement(new SyntaxList<AttributeListSyntax>(), SyntaxFactory.Token(SyntaxKind.IfKeyword), default(SyntaxToken), GenerateIdentifierName(), default(SyntaxToken), GenerateBlock(), default(ElseClauseSyntax));
 
         private static ElseClauseSyntax GenerateElseClause()
             => SyntaxFactory.ElseClause(SyntaxFactory.Token(SyntaxKind.ElseKeyword), GenerateBlock());
@@ -11753,9 +11753,9 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
 
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(SyntaxKind.IfKeyword, node.IfKeyword.Kind());
-            Assert.Equal(SyntaxKind.OpenParenToken, node.OpenParenToken.Kind());
+            Assert.Equal(SyntaxKind.None, node.OpenParenToken.Kind());
             Assert.NotNull(node.Condition);
-            Assert.Equal(SyntaxKind.CloseParenToken, node.CloseParenToken.Kind());
+            Assert.Equal(SyntaxKind.None, node.CloseParenToken.Kind());
             Assert.NotNull(node.Statement);
             Assert.Null(node.Else);
             var newNode = node.WithAttributeLists(node.AttributeLists).WithIfKeyword(node.IfKeyword).WithOpenParenToken(node.OpenParenToken).WithCondition(node.Condition).WithCloseParenToken(node.CloseParenToken).WithStatement(node.Statement).WithElse(node.Else);

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -12,10 +12,13 @@ Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFil
 Microsoft.CodeAnalysis.SyntaxNode.FindToken(int position, bool findInsideTrivia = false, bool findInsideSkippedTrivia = false) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxNode.GetLastToken(bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false, System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate = null) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxNode.HasErrors.get -> bool
+Microsoft.CodeAnalysis.SyntaxNodeOrToken.GetLeadingTriviaExceptSkippedTokens() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxTrivia>
+Microsoft.CodeAnalysis.SyntaxNodeOrToken.GetLeadingTriviaSkippedTokens() -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxTrivia>
+Microsoft.CodeAnalysis.SyntaxNodeOrToken.HasLeadingTriviaExceptSkippedTokens.get -> bool
+Microsoft.CodeAnalysis.SyntaxNodeOrToken.HasLeadingTriviaSkippedTokens.get -> bool
 Microsoft.CodeAnalysis.SyntaxNodeOrToken.TokenIndex.get -> int
-Microsoft.CodeAnalysis.SyntaxToken.FindNextToken(System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
-Microsoft.CodeAnalysis.SyntaxToken.FindPreviousToken(System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate, bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
-Microsoft.CodeAnalysis.SyntaxToken.GetFirstTokenOnLine(bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false) -> Microsoft.CodeAnalysis.SyntaxToken?
+Microsoft.CodeAnalysis.SyntaxNodeOrToken.WithLeadingTrivia(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxTrivia> trivia, bool preservePosition = false) -> Microsoft.CodeAnalysis.SyntaxNodeOrToken
+Microsoft.CodeAnalysis.SyntaxToken.WithLeadingTrivia(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxTrivia> trivia, int position = 0, int index = 0) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.SyntaxTreeOptionsProvider() -> void
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.IsGenerated(Microsoft.CodeAnalysis.SyntaxTree tree) -> bool?

--- a/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
+++ b/src/Compilers/Core/Portable/Syntax/SyntaxToken.cs
@@ -477,12 +477,12 @@ namespace Microsoft.CodeAnalysis
         /// <summary>
         /// Creates a new token from this token with the leading trivia specified..
         /// </summary>
-        public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia)
+        public SyntaxToken WithLeadingTrivia(IEnumerable<SyntaxTrivia>? trivia, int position = 0, int index = 0)
         {
             var greenList = trivia?.Select(t => t.RequiredUnderlyingNode);
 
             return Node != null
-                ? new SyntaxToken(null, Node.WithLeadingTrivia(Node.CreateList(greenList)), position: 0, index: 0)
+                ? new SyntaxToken(null, Node.WithLeadingTrivia(Node.CreateList(greenList)), position: position, index: index)
                 : default(SyntaxToken);
         }
 

--- a/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
+++ b/src/Workspaces/SharedUtilitiesAndExtensions/Compiler/CSharp/Services/SyntaxFacts/CSharpSyntaxFacts.cs
@@ -1550,7 +1550,12 @@ namespace Microsoft.CodeAnalysis.CSharp.LanguageServices
                 return false;
             }
 
-            return IsOnHeader(root, position, node, node.CloseParenToken);
+            var lastToken = node.CloseParenToken;
+            if (lastToken.IsMissing || lastToken.Width() == 0) lastToken = node.Condition.GetLastToken();
+            if (lastToken.IsMissing || lastToken.Width() == 0) lastToken = node.OpenParenToken;
+            if (lastToken.IsMissing || lastToken.Width() == 0) lastToken = node.IfKeyword;
+
+            return IsOnHeader(root, position, node, lastToken);
         }
 
         public bool IsOnWhileStatementHeader(SyntaxNode root, int position, out SyntaxNode whileStatement)


### PR DESCRIPTION
Updates if/else statement syntax to make it more compact and convenient:

* condition expression doesn't need to be surrounded by parenthesis
* => is allowed if statement start
* else can have expression statement immediately following without any block braces

Enables syntax like:
```
if condition => print("1") // no parenthesis and => statement indicator

if condition {
}

if (condition) print("1")

if condition => print("1") else print("2") // followed by immediate else statement without parenthesis

if condition => print("1")
else if other => print("2")
else => print("3")

if condition => print("1")
else if (other) print("2")
else print("3")
```