### PR TITLE
Feature/if else declaration in condition

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Operators.cs
@@ -756,12 +756,30 @@ namespace Microsoft.CodeAnalysis.CSharp
                 binary = childAsBinary;
             }
 
-            BoundExpression left = BindRValueWithoutTargetType(child, diagnostics);
+            BoundExpression left = null;
+            if (IsBindingIfStatementCondition && WillRewriteConditionExpression(child))
+            {
+                left = BindBooleanExpression(child, diagnostics, ignoreImplicitCastError: true);
+            }
+            else
+            {
+                left = BindRValueWithoutTargetType(child, diagnostics);
+            }
 
             do
             {
                 binary = (BinaryExpressionSyntax)child.Parent;
-                BoundExpression right = BindRValueWithoutTargetType(binary.Right, diagnostics);
+
+                BoundExpression right = null;
+                if (IsBindingIfStatementCondition && WillRewriteConditionExpression(binary.Right))
+                {
+                    right = BindBooleanExpression(binary.Right, diagnostics, ignoreImplicitCastError: true);
+                }
+                else
+                {
+                    right = BindRValueWithoutTargetType(binary.Right, diagnostics);
+                }
+
                 left = BindConditionalLogicalOperator(binary, left, right, diagnostics);
                 child = binary;
             }

--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -763,7 +763,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return disposeMethod;
         }
 
-        private TypeWithAnnotations BindVariableTypeWithAnnotations(CSharpSyntaxNode declarationNode, DiagnosticBag diagnostics, TypeSyntax typeSyntax, ref bool isConst, out bool isVar, out AliasSymbol alias)
+        private TypeWithAnnotations BindVariableTypeWithAnnotations(CSharpSyntaxNode declarationNode, DiagnosticBag diagnostics, TypeSyntax typeSyntax, ref bool isConst, out bool isVar, out AliasSymbol alias, bool makeVar = false)
         {
             Debug.Assert(
                 declarationNode is VariableDesignationSyntax ||
@@ -789,6 +789,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     }
                 }
             }
+
+            if (makeVar) isVar = true;
 
             Debug.Assert(declType.HasType || isVar);
 
@@ -973,13 +975,39 @@ namespace Microsoft.CodeAnalysis.CSharp
             bool includeBoundType,
             CSharpSyntaxNode associatedSyntaxNode = null)
         {
-            Debug.Assert(declarator != null);
+            return BindVariableDeclaration(
+                localSymbol,
+                kind,
+                isVar,
+                declarator.Initializer,
+                typeSyntax,
+                declTypeOpt,
+                aliasOpt,
+                diagnostics,
+                includeBoundType,
+                associatedSyntaxNode ?? declarator
+            );
+        }
+
+        protected BoundLocalDeclaration BindVariableDeclaration(
+            SourceLocalSymbol localSymbol,
+            LocalDeclarationKind kind,
+            bool isVar,
+            EqualsValueClauseSyntax equalsClauseSyntax,
+            TypeSyntax typeSyntax,
+            TypeWithAnnotations declTypeOpt,
+            AliasSymbol aliasOpt,
+            DiagnosticBag diagnostics,
+            bool includeBoundType,
+            CSharpSyntaxNode associatedSyntaxNode = null,
+            VariableDeclaratorSyntax declarator = null)
+        {
             Debug.Assert(declTypeOpt.HasType || isVar);
             Debug.Assert(typeSyntax != null);
 
             var localDiagnostics = DiagnosticBag.GetInstance();
             // if we are not given desired syntax, we use declarator
-            associatedSyntaxNode = associatedSyntaxNode ?? declarator;
+            associatedSyntaxNode = associatedSyntaxNode ?? declarator as CSharpSyntaxNode ?? equalsClauseSyntax;
 
             // Check for variable declaration errors.
             // Use the binder that owns the scope for the local because this (the current) binder
@@ -992,11 +1020,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 CheckRefLocalInAsyncOrIteratorMethod(localSymbol.IdentifierToken, diagnostics);
             }
 
-            EqualsValueClauseSyntax equalsClauseSyntax = declarator.Initializer;
-
             BindValueKind valueKind;
             ExpressionSyntax value;
-            if (!IsInitializerRefKindValid(equalsClauseSyntax, declarator, localSymbol.RefKind, diagnostics, out valueKind, out value))
+            if (!IsInitializerRefKindValid(equalsClauseSyntax, equalsClauseSyntax, localSymbol.RefKind, diagnostics, out valueKind, out value))
             {
                 hasErrors = true;
             }
@@ -1006,7 +1032,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             {
                 aliasOpt = null;
 
-                initializerOpt = BindInferredVariableInitializer(diagnostics, value, valueKind, localSymbol.RefKind, declarator);
+                initializerOpt = BindInferredVariableInitializer(diagnostics, value, valueKind, localSymbol.RefKind, associatedSyntaxNode);
 
                 // If we got a good result then swap the inferred type for the "var"
                 TypeSymbol initializerType = initializerOpt?.Type;
@@ -1016,7 +1042,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                     if (declTypeOpt.IsVoidType())
                     {
-                        Error(localDiagnostics, ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, declarator, declTypeOpt.Type);
+                        Error(localDiagnostics, ErrorCode.ERR_ImplicitlyTypedVariableAssignedBadValue, associatedSyntaxNode, declTypeOpt.Type);
                         declTypeOpt = TypeWithAnnotations.Create(CreateErrorType("var"));
                         hasErrors = true;
                     }
@@ -1067,7 +1093,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (!hasErrors)
                     {
-                        Error(localDiagnostics, ErrorCode.ERR_ImplicitlyTypedLocalCannotBeFixed, declarator);
+                        Error(localDiagnostics, ErrorCode.ERR_ImplicitlyTypedLocalCannotBeFixed, associatedSyntaxNode);
                         hasErrors = true;
                     }
                 }
@@ -1076,7 +1102,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 {
                     if (!hasErrors)
                     {
-                        Error(localDiagnostics, declTypeOpt.Type.IsFunctionPointer() ? ErrorCode.ERR_CannotUseFunctionPointerAsFixedLocal : ErrorCode.ERR_BadFixedInitType, declarator);
+                        Error(localDiagnostics, declTypeOpt.Type.IsFunctionPointer() ? ErrorCode.ERR_CannotUseFunctionPointerAsFixedLocal : ErrorCode.ERR_BadFixedInitType, associatedSyntaxNode);
                         hasErrors = true;
                     }
                 }
@@ -1105,7 +1131,12 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            ImmutableArray<BoundExpression> arguments = BindDeclaratorArguments(declarator, localDiagnostics);
+
+            ImmutableArray<BoundExpression> arguments = default;
+            if (declarator != null)
+            {
+                arguments = BindDeclaratorArguments(declarator, localDiagnostics);
+            }
 
             if (kind == LocalDeclarationKind.FixedVariable || kind == LocalDeclarationKind.UsingVariable)
             {
@@ -1116,7 +1147,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 if (initializerOpt == null)
                 {
-                    Error(localDiagnostics, ErrorCode.ERR_FixedMustInit, declarator);
+                    Error(localDiagnostics, ErrorCode.ERR_FixedMustInit, associatedSyntaxNode);
                     hasErrors = true;
                 }
             }
@@ -1396,6 +1427,39 @@ namespace Microsoft.CodeAnalysis.CSharp
                 hasErrors);
         }
 
+        private BoundExpression BindAssignmentLocalDeclaration(AssignmentExpressionSyntax node, DeclarationExpressionSyntax decl, SingleVariableDesignationSyntax designation, DiagnosticBag diagnostics)
+        {
+            var typeSyntax = decl.Type.SkipRef(out _);
+
+            bool isVar;
+            bool isConst = false;
+            AliasSymbol alias;
+            TypeWithAnnotations declType = BindVariableTypeWithAnnotations(decl, diagnostics, typeSyntax, ref isConst, isVar: out isVar, alias: out alias, makeVar: true);
+
+            // prepare the local symbol
+            var kind = isConst ? LocalDeclarationKind.Constant : LocalDeclarationKind.RegularVariable;
+            var equalsClause = SyntaxFactory.EqualsValueClause(node.Right);
+            var symbol = LocateDeclaredVariableSymbol(designation.Identifier, typeSyntax, equalsClause, kind);
+
+            var boundDecl = BindVariableDeclaration(
+                symbol,
+                kind,
+                isVar,
+                equalsClause,
+                typeSyntax,
+                declType,
+                null,
+                diagnostics,
+                includeBoundType: true,
+                associatedSyntaxNode: node
+            );
+
+            var local = boundDecl.LocalSymbol;
+
+            var boundLocal = new BoundLocal(decl, local, null, local.Type, decl.Type.HasErrors || local.Type.IsErrorType());
+            return new BoundAssignmentOperator(node, boundLocal, boundDecl.InitializerOpt, false, local.Type, boundDecl.InitializerOpt?.HasErrors ?? false);
+        }
+
         private BoundExpression BindAssignment(AssignmentExpressionSyntax node, DiagnosticBag diagnostics)
         {
             Debug.Assert(node != null);
@@ -1404,9 +1468,20 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             node.Left.CheckDeconstructionCompatibleArgument(diagnostics);
 
-            if (node.Left.Kind() == SyntaxKind.TupleExpression || node.Left.Kind() == SyntaxKind.DeclarationExpression)
+            if (node.Left.Kind() == SyntaxKind.TupleExpression)
             {
                 return BindDeconstruction(node, diagnostics);
+            }
+            else if (node.Left.Kind() == SyntaxKind.DeclarationExpression)
+            {
+                if (node.Left is DeclarationExpressionSyntax declExpr && declExpr.Designation is SingleVariableDesignationSyntax singleDesign)
+                {
+                    return BindAssignmentLocalDeclaration(node, declExpr, singleDesign, diagnostics);
+                }
+                else
+                {
+                    return BindDeconstruction(node, diagnostics);
+                }
             }
 
             BindValueKind lhsKind;

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -336,6 +336,23 @@ namespace Microsoft.CodeAnalysis.CSharp
         }
     }
 
+    public static class BoundConversionSyntaxNodeExtensions
+    {
+        private static readonly SyntaxAnnotation FakeConversionAnnotation = new SyntaxAnnotation("FakeConversion");
+
+        public static TNode WithExpectedRewrite<TNode>(this TNode node)
+            where TNode : SyntaxNode
+        {
+            return node.WithAdditionalAnnotations(FakeConversionAnnotation);
+        }
+
+        public static bool IsExpectedRewrite<TNode>(this TNode node)
+            where TNode : SyntaxNode
+        {
+            return node.HasAnnotation(FakeConversionAnnotation);
+        }
+    }
+
     internal partial class BoundConversion
     {
         public override ConstantValue? ConstantValue

--- a/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/Constructors.cs
@@ -303,8 +303,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConversionGroup? conversionGroupOpt,
             ConstantValue? constantValueOpt,
             TypeSymbol type,
-            bool hasErrors = false)
+            bool hasErrors = false,
+            bool allowInvalidConversion = false)
         {
+            hasErrors = allowInvalidConversion ? false : hasErrors || !conversion.IsValid;
             return new BoundConversion(
                 syntax,
                 operand,
@@ -314,7 +316,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversionGroupOpt,
                 constantValueOpt,
                 type,
-                hasErrors || !conversion.IsValid)
+                hasErrors,
+                allowInvalidConversion)
             {
                 WasCompilerGenerated = true
             };
@@ -329,7 +332,8 @@ namespace Microsoft.CodeAnalysis.CSharp
             ConversionGroup? conversionGroupOpt,
             ConstantValue? constantValueOpt,
             TypeSymbol type,
-            bool hasErrors = false)
+            bool hasErrors = false,
+            bool allowInvalidConversion = false)
             : this(
                 syntax,
                 operand,
@@ -341,7 +345,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 conversionGroupOpt,
                 conversion.OriginalUserDefinedConversions,
                 type: type,
-                hasErrors: hasErrors || !conversion.IsValid)
+                hasErrors: allowInvalidConversion ? false : hasErrors || !conversion.IsValid)
         { }
 
         public BoundConversion(

--- a/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/Instrumentation/DebugInfoInjector.cs
@@ -315,7 +315,7 @@ namespace Microsoft.CodeAnalysis.CSharp
                 base.InstrumentIfStatement(original, rewritten),
                 TextSpan.FromBounds(
                     syntax.IfKeyword.SpanStart,
-                    syntax.CloseParenToken.Span.End),
+                    syntax.GetLastHeaderToken().Span.End),
                 original.HasErrors);
         }
 

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -12234,8 +12234,16 @@ tryAgain:
                         opToken = CheckFeatureAvailability(opToken, MessageID.IDS_FeatureCoalesceAssignmentExpression);
                     }
 
+                    // convert simple expression into a variable declaration argument
+                    if (leftOperand is IdentifierNameSyntax identName)
+                    {
+                        var designation = _syntaxFactory.SingleVariableDesignation(identName.Identifier);
+                        var declType = SyntaxFactory.FakeTypeIdentifier(_syntaxFactory, isVar: true);
+                        var decl = _syntaxFactory.DeclarationExpression(designation, declType);
+                        leftOperand = _syntaxFactory.AssignmentExpression(opKind, decl, opToken, rhs);
+                    }
                     // convert the tuple expression into a tuple expression with declarations if possible - only for "identifier" expressions
-                    if (leftOperand is TupleExpressionSyntax tupleExpr)
+                    else if (leftOperand is TupleExpressionSyntax tupleExpr)
                     {
                         var invalidDeclaration = false;
                         var arguments = SeparatedSyntaxListBuilder<ArgumentSyntax>.Create();

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser.cs
@@ -12001,9 +12001,9 @@ tryAgain:
             return SyntaxFacts.IsBinaryExpression(kind);
         }
 
-        private static bool IsBinaryRelationOperator(SyntaxKind kind)
+        private static bool IsBinaryBooleanConditionOperator(SyntaxKind kind)
         {
-            return SyntaxFacts.IsBinaryRelationExpression(kind);
+            return SyntaxFacts.IsBinaryBooleanConditionOperator(kind);
         }
 
         private static bool IsExpectedAssignmentOperator(SyntaxKind kind)
@@ -12252,7 +12252,7 @@ tryAgain:
                     break;
                 }
 
-                if (!IsBinaryRelationExpressionAllowed && IsBinaryRelationOperator(tk))
+                if (!IsBinaryRelationExpressionAllowed && IsBinaryBooleanConditionOperator(tk))
                 {
                     break;
                 }
@@ -12282,7 +12282,7 @@ tryAgain:
 
                     // check for special case where the LHS is an assignment - then followed by a relational operator or i operator
                     var lhsAssignmentComparison = IsSimpleAssignment && leftOperand is AssignmentExpressionSyntax && (
-                        IsBinaryRelationOperator(tk) || tk == SyntaxKind.IsExpression
+                        IsBinaryBooleanConditionOperator(tk) || tk == SyntaxKind.IsExpression
                     );
 
                     if (!lhsAssignmentComparison)

--- a/src/Compilers/CSharp/Portable/Parser/LanguageParser_Blocks.cs
+++ b/src/Compilers/CSharp/Portable/Parser/LanguageParser_Blocks.cs
@@ -17,6 +17,55 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
 
     internal partial class LanguageParser
     {
+        #region Blocks - statements
+        private BlockSyntax ParseArrowStatementBlock(SyntaxList<AttributeListSyntax> attributes = default, bool semicolonRequired = false, bool isSimpleExpr = true)
+        {
+            var arrowToken = EatToken(SyntaxKind.EqualsGreaterThanToken);
+
+            var stat = ParseStatementCore(
+                attributes,
+                semicolonRequired: semicolonRequired,
+                isSimpleExpr: isSimpleExpr
+            );
+
+            // skip the arrow, it's not part of the syntax
+            stat = AddLeadingSkippedSyntax(stat, arrowToken);
+
+            var block = SyntaxFactory.FakeBlock(
+                _syntaxFactory,
+                statements: SyntaxFactory.List<StatementSyntax>(stat)
+            );
+
+            return block;
+        }
+
+        private BlockSyntax ParseStatementBlock(SyntaxList<AttributeListSyntax> attributes = default, bool semicolonRequired = false, bool isSimpleExpr = true)
+        {
+            var stat = ParseStatementCore(
+                attributes,
+                semicolonRequired: semicolonRequired,
+                isSimpleExpr: isSimpleExpr,
+                allowLambdaExpr: !isSimpleExpr
+            );
+
+            return SyntaxFactory.FakeBlock(
+                _syntaxFactory,
+                statements: SyntaxFactory.List<StatementSyntax>(stat)
+            );
+        }
+
+        private StatementSyntax ParseSimpleStatement(SyntaxList<AttributeListSyntax> attributes = default, bool semicolonRequired = false, bool isSimpleExpr = true)
+        {
+            return ParseStatementCore(
+                attributes,
+                semicolonRequired: semicolonRequired,
+                isSimpleExpr: isSimpleExpr,
+                allowLambdaExpr: !isSimpleExpr
+            );
+        }
+        #endregion
+
+        #region Blocks - expression statements
         private BlockSyntax ParseArrowExprStatementBlock(SyntaxList<AttributeListSyntax> attributes = default, bool semicolonRequired = false, bool simpleExpr = true)
         {
             var wasSimpleExpression = IsSimpleExpression;
@@ -64,5 +113,6 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 AllowLambdaExpression = didAllowLambdaExpression;
             }
         }
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -104,6 +104,8 @@ static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.UsingDirective(Microsoft.Code
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VariableDeclaration() -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclarationSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VariableDeclaration(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax> variables) -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclarationSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VariableDeclarator(Microsoft.CodeAnalysis.SyntaxToken identifier, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type, Microsoft.CodeAnalysis.CSharp.Syntax.BracketedArgumentListSyntax argumentList, Microsoft.CodeAnalysis.CSharp.Syntax.EqualsValueClauseSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax
+static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.GetBinaryRelationExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind token) -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.IsBinaryRelationExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind token) -> bool
 static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.IsMemberModifier(Microsoft.CodeAnalysis.CSharp.SyntaxKind kind) -> bool
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitDefaultConstraint(Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitDefaultConstraint(Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax node) -> TResult

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
+Microsoft.CodeAnalysis.CSharp.BoundConversionSyntaxNodeExtensions
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.FindToken(int position, bool findInsideTrivia = false, bool findInsideSkippedTrivia = false) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Conversion.IsConditionalExpression.get -> bool
 Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.AddModifiers(params Microsoft.CodeAnalysis.SyntaxToken[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax
@@ -104,8 +105,8 @@ static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.UsingDirective(Microsoft.Code
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VariableDeclaration() -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclarationSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VariableDeclaration(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax> variables) -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclarationSyntax
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.VariableDeclarator(Microsoft.CodeAnalysis.SyntaxToken identifier, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type, Microsoft.CodeAnalysis.CSharp.Syntax.BracketedArgumentListSyntax argumentList, Microsoft.CodeAnalysis.CSharp.Syntax.EqualsValueClauseSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax
-static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.GetBinaryRelationExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind token) -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
-static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.IsBinaryRelationExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind token) -> bool
+static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.GetBinaryBooleanConditionExpression(Microsoft.CodeAnalysis.CSharp.SyntaxKind token) -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.IsBinaryBooleanConditionOperator(Microsoft.CodeAnalysis.CSharp.SyntaxKind token) -> bool
 static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.IsMemberModifier(Microsoft.CodeAnalysis.CSharp.SyntaxKind kind) -> bool
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor.VisitDefaultConstraint(Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax node) -> void
 virtual Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult>.VisitDefaultConstraint(Microsoft.CodeAnalysis.CSharp.Syntax.DefaultConstraintSyntax node) -> TResult

--- a/src/Compilers/CSharp/Portable/Rewriters/ImplicitIfConditionRewriter.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/ImplicitIfConditionRewriter.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Diagnostics;
+using Microsoft.CodeAnalysis.CSharp.Symbols;
+
+namespace Microsoft.CodeAnalysis.CSharp.Rewriters
+{
+    internal sealed class ImplicitIfConditionRewriter : BoundTreeRewriterWithStackGuard
+    {
+        private readonly SyntheticBoundNodeFactory _F;
+        private readonly DiagnosticBag _diagnostics;
+
+        private ImplicitIfConditionRewriter(
+            MethodSymbol containingMethod,
+            NamedTypeSymbol containingType,
+            SyntheticBoundNodeFactory factory,
+            DiagnosticBag diagnostics)
+        {
+            _F = factory;
+            _F.CurrentType = containingType;
+            _F.CurrentFunction = containingMethod;
+            _diagnostics = diagnostics;
+        }
+
+        public static BoundBlock Rewrite(
+            MethodSymbol containingSymbol,
+            NamedTypeSymbol containingType,
+            BoundBlock block,
+            TypeCompilationState compilationState,
+            DiagnosticBag diagnostics)
+        {
+            Debug.Assert(containingSymbol != null);
+            Debug.Assert((object)containingType != null);
+            Debug.Assert(block != null);
+            Debug.Assert(compilationState != null);
+            Debug.Assert(diagnostics != null);
+
+            var factory = new SyntheticBoundNodeFactory(containingSymbol, block.Syntax, compilationState, diagnostics);
+            var rewriter = new ImplicitIfConditionRewriter(containingSymbol, containingType, factory, diagnostics);
+            var newBlock = rewriter.Visit(block) as BoundBlock;
+            return newBlock;
+        }
+
+        protected bool IsInIfStatementCondition { get; set; }
+
+        public override BoundNode VisitIfStatement(BoundIfStatement node)
+        {
+            // Special handling for:
+            // 1. if condition is a local declaration
+            // 2. everything else...
+
+            var wasInIfStatementCondition = IsInIfStatementCondition;
+            IsInIfStatementCondition = true;
+            try
+            {
+                return base.VisitIfStatement(node);
+            }
+            finally
+            {
+                IsInIfStatementCondition = wasInIfStatementCondition;
+            }
+        }
+
+        public override BoundNode VisitConversion(BoundConversion node)
+        {
+            var newNode = TryRewriteConditionExpression(node);
+            if (newNode != null) return newNode;
+            return base.VisitConversion(node);
+        }
+
+        private BoundNode TryRewriteConditionExpression(BoundConversion node)
+        {
+            if (!IsInIfStatementCondition) return null;
+
+            // no need to do anything if we have a valid conversion
+            if (node.Syntax?.IsExpectedRewrite() == false) return null;
+
+            // we need to rewrite the operand expression into a "expr != null" if it's a nullable
+            if (node.Operand.Type.IsNonNullableValueType()) return null;
+
+            // OK, it's a nullable, we can do the condition check
+            var newCondition = _F.Binary(BinaryOperatorKind.NotEqual, node.Type, node.Operand, _F.Null(node.Operand.Type));
+            var newConversion = _F.Convert(node.Type, newCondition);
+
+            return newConversion;
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Rewriters/SyntaxRewritesPass.cs
+++ b/src/Compilers/CSharp/Portable/Rewriters/SyntaxRewritesPass.cs
@@ -13,12 +13,22 @@ namespace Microsoft.CodeAnalysis.CSharp.Rewriters
             bool hasTrailingExpression,
             bool originalBodyNested)
         {
+            // rewrite try/catch statements to promote variable declarations to the outer scope
             block = MethodInlineTryCatchBlockRewriter.Rewrite(
-                        method,
-                        method.ContainingType,
-                        block,
-                        compilationState,
-                        diagnostics);
+                method,
+                method.ContainingType,
+                block,
+                compilationState,
+                diagnostics
+            );
+
+            block = ImplicitIfConditionRewriter.Rewrite(
+                method,
+                method.ContainingType,
+                block,
+                compilationState,
+                diagnostics
+            );
 
             return block;
         }

--- a/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/IfStatementSyntax.cs
@@ -10,6 +10,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
 {
     public partial class IfStatementSyntax
     {
+        public SyntaxToken GetLastHeaderToken()
+        {
+            var lastToken = CloseParenToken;
+            if (lastToken.IsMissing || lastToken.Width == 0) lastToken = Condition.GetLastToken();
+            if (lastToken.IsMissing || lastToken.Width == 0) lastToken = OpenParenToken;
+            if (lastToken.IsMissing || lastToken.Width == 0) lastToken = IfKeyword;
+            return lastToken;
+        }
+
         public IfStatementSyntax Update(SyntaxToken ifKeyword, SyntaxToken openParenToken, ExpressionSyntax condition, SyntaxToken closeParenToken, StatementSyntax statement, ElseClauseSyntax @else)
             => Update(attributeLists: default, ifKeyword, openParenToken, condition, closeParenToken, statement, @else);
     }

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -591,9 +591,35 @@ namespace Microsoft.CodeAnalysis.CSharp
             return GetBinaryExpression(token) != SyntaxKind.None;
         }
 
+        public static bool IsBinaryRelationExpression(SyntaxKind token)
+        {
+            return GetBinaryRelationExpression(token) != SyntaxKind.None;
+        }
+
         public static bool IsBinaryExpressionOperatorToken(SyntaxKind token)
         {
             return GetBinaryExpression(token) != SyntaxKind.None;
+        }
+
+        public static SyntaxKind GetBinaryRelationExpression(SyntaxKind token)
+        {
+            switch (token)
+            {
+                case SyntaxKind.GreaterThanEqualsToken:
+                    return SyntaxKind.GreaterThanOrEqualExpression;
+                case SyntaxKind.GreaterThanToken:
+                    return SyntaxKind.GreaterThanExpression;
+                case SyntaxKind.LessThanEqualsToken:
+                    return SyntaxKind.LessThanOrEqualExpression;
+                case SyntaxKind.LessThanToken:
+                    return SyntaxKind.LessThanExpression;
+                case SyntaxKind.EqualsEqualsToken:
+                    return SyntaxKind.EqualsExpression;
+                case SyntaxKind.ExclamationEqualsToken:
+                    return SyntaxKind.NotEqualsExpression;
+                default:
+                    return SyntaxKind.None;
+            }
         }
 
         public static SyntaxKind GetBinaryExpression(SyntaxKind token)

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -591,9 +591,9 @@ namespace Microsoft.CodeAnalysis.CSharp
             return GetBinaryExpression(token) != SyntaxKind.None;
         }
 
-        public static bool IsBinaryRelationExpression(SyntaxKind token)
+        public static bool IsBinaryBooleanConditionOperator(SyntaxKind token)
         {
-            return GetBinaryRelationExpression(token) != SyntaxKind.None;
+            return GetBinaryBooleanConditionExpression(token) != SyntaxKind.None;
         }
 
         public static bool IsBinaryExpressionOperatorToken(SyntaxKind token)
@@ -601,22 +601,36 @@ namespace Microsoft.CodeAnalysis.CSharp
             return GetBinaryExpression(token) != SyntaxKind.None;
         }
 
-        public static SyntaxKind GetBinaryRelationExpression(SyntaxKind token)
+        public static SyntaxKind GetBinaryBooleanConditionExpression(SyntaxKind token)
         {
             switch (token)
             {
-                case SyntaxKind.GreaterThanEqualsToken:
-                    return SyntaxKind.GreaterThanOrEqualExpression;
-                case SyntaxKind.GreaterThanToken:
-                    return SyntaxKind.GreaterThanExpression;
-                case SyntaxKind.LessThanEqualsToken:
-                    return SyntaxKind.LessThanOrEqualExpression;
-                case SyntaxKind.LessThanToken:
-                    return SyntaxKind.LessThanExpression;
+                case SyntaxKind.BarToken:
+                    return SyntaxKind.BitwiseOrExpression;
+                case SyntaxKind.CaretToken:
+                    return SyntaxKind.ExclusiveOrExpression;
+                case SyntaxKind.AmpersandToken:
+                    return SyntaxKind.BitwiseAndExpression;
                 case SyntaxKind.EqualsEqualsToken:
                     return SyntaxKind.EqualsExpression;
                 case SyntaxKind.ExclamationEqualsToken:
                     return SyntaxKind.NotEqualsExpression;
+                case SyntaxKind.LessThanToken:
+                    return SyntaxKind.LessThanExpression;
+                case SyntaxKind.LessThanEqualsToken:
+                    return SyntaxKind.LessThanOrEqualExpression;
+                case SyntaxKind.GreaterThanToken:
+                    return SyntaxKind.GreaterThanExpression;
+                case SyntaxKind.GreaterThanEqualsToken:
+                    return SyntaxKind.GreaterThanOrEqualExpression;
+                case SyntaxKind.LessThanLessThanToken:
+                    return SyntaxKind.LeftShiftExpression;
+                case SyntaxKind.GreaterThanGreaterThanToken:
+                    return SyntaxKind.RightShiftExpression;
+                case SyntaxKind.AmpersandAmpersandToken:
+                    return SyntaxKind.LogicalAndExpression;
+                case SyntaxKind.BarBarToken:
+                    return SyntaxKind.LogicalOrExpression;
                 default:
                     return SyntaxKind.None;
             }


### PR DESCRIPTION
Updates syntax for if statements to allow declaring variables in the condition expression - enabling short / concise if statements with error checking - also updates default != null checks for nullable types.

Enables:
* declare/assign variables in condition expression
* check for "not null" for nullable types without "!=" expression

Enables the following syntax:
```
if value := GetValue() {}
if user := GetUser() is AdminUser adminUser {
  // user is admin ... and we can use the adminUser
}
else {
  // user is not admin
}
if doCheck && checkedValue := GetValueAndCheck() {}

optIntValue int? = null
if optIntValue {
  // only if we have the optIntValue ... it's not null ... but doesn't actually evaluate the value of it ...
}

obj object = null
if obj {
  // only if obj != null 
}
```

