### PR TITLE
Feature/function spread args input

### DIFF
--- a/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Binder_Statements.cs
@@ -1546,7 +1546,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             return op1.SetInferredTypeWithAnnotations(TypeWithAnnotations.Create(inferredType));
         }
 
-        private BoundAssignmentOperator BindAssignment(
+        internal BoundAssignmentOperator BindAssignment(
             SyntaxNode node,
             BoundExpression op1,
             BoundExpression op2,

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/AnalyzedArguments.cs
@@ -51,6 +51,16 @@ namespace Microsoft.CodeAnalysis.CSharp
             return syntax == null ? null : syntax.Identifier.ValueText;
         }
 
+        public IdentifierNameSyntax NameSyntax(int i)
+        {
+            if (Names.Count == 0)
+            {
+                return null;
+            }
+
+            return Names[i];
+        }
+
         public ImmutableArray<string> GetNames()
         {
             int count = this.Names.Count;
@@ -120,6 +130,21 @@ namespace Microsoft.CodeAnalysis.CSharp
 
                 return false;
             }
+        }
+
+        public void UpdateFrom(AnalyzedArguments other)
+        {
+            Arguments.Clear();
+            Arguments.AddRange(other.Arguments);
+
+            Names.Clear();
+            Names.AddRange(other.Names);
+
+            RefKinds.Clear();
+            RefKinds.AddRange(other.RefKinds);
+
+            IsExtensionMethodInvocation = other.IsExtensionMethodInvocation;
+            _lazyHasDynamicArgument = other._lazyHasDynamicArgument;
         }
 
         #region "Poolable"

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/ArgumentAnalysisResult.cs
@@ -14,6 +14,17 @@ namespace Microsoft.CodeAnalysis.CSharp
         public readonly int ParameterPosition;
         public readonly ArgumentAnalysisResultKind Kind;
 
+        public int ArgumentFromParameter(int param)
+        {
+            Debug.Assert(param >= 0);
+            if (ArgsToParamsOpt.IsDefault) return param;
+            for (var i = 0; i < ArgsToParamsOpt.Length; ++i)
+            {
+                if (ArgsToParamsOpt[i] == param) return i;
+            }
+            return -1;
+        }
+
         public int ParameterFromArgument(int arg)
         {
             Debug.Assert(arg >= 0);
@@ -34,7 +45,10 @@ namespace Microsoft.CodeAnalysis.CSharp
             this.ArgumentPosition = argumentPosition;
             this.ParameterPosition = parameterPosition;
             this.ArgsToParamsOpt = argsToParamsOpt;
+            this.HasSpreadParameters = false;
         }
+
+        public bool HasSpreadParameters { get; set; }
 
         public bool IsValid
         {

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3342,7 +3342,7 @@ namespace Microsoft.CodeAnalysis.CSharp
 
             // new instance of the parameter type with an object initializer
             var initializer = nodeFactory.ObjectInitializer(implicitReceiver, spreadParam.Type, initExpressions.ToImmutableAndFree(), arguments.Argument(0).Syntax.Parent);
-            return nodeFactory.New((NamedTypeSymbol)spreadParam.Type).UpdateInitializer(initializer);
+            return nodeFactory.TryNew((NamedTypeSymbol)spreadParam.Type)?.UpdateInitializer(initializer) ?? nodeFactory.Null(spreadParam.Type);
         }
 
         private MemberResolutionResult<TMember> IsMemberApplicableInExpandedForm<TMember>(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -3319,7 +3319,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                 var argName = arguments.Name(argIndex);
 
                 // add a member initializer expression for the arg ... to the matching member
-                var argMember = spreadTypeMembers.FirstOrDefault(m => m.Name == argName);
+
+                var argMember = SpreadParamHelpers.GetFirstPossibleSpreadParamMember(spreadTypeMembers, argName);
                 if (argMember == null)
                 {
                     // error ... must match a member to be part of the spread ...

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using Microsoft.Cci;
 using Microsoft.CodeAnalysis.CSharp.Symbols;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.PooledObjects;
 using Roslyn.Utilities;
 
@@ -3077,6 +3078,29 @@ namespace Microsoft.CodeAnalysis.CSharp
             return new EffectiveParameters(types.ToImmutableAndFree(), refKinds);
         }
 
+        class SpreadArgumentAnalysis
+        {
+            public SpreadArgumentAnalysis(int paramIndex)
+            {
+                ParameterIndex = paramIndex;
+            }
+
+            public int ParameterIndex { get; set; }
+            public ArrayBuilder<int> Arguments { get; set; }
+
+            public void AddArgument(int arg)
+            {
+                Arguments ??= ArrayBuilder<int>.GetInstance();
+                Arguments.Add(arg);
+            }
+
+            public void Free()
+            {
+                Arguments.Free();
+                Arguments = null;
+            }
+        }
+
         private MemberResolutionResult<TMember> IsMemberApplicableInNormalForm<TMember>(
             TMember member,                // method or property
             TMember leastOverriddenMember, // method or property
@@ -3092,6 +3116,11 @@ namespace Microsoft.CodeAnalysis.CSharp
             // AnalyzeArguments matches arguments to parameter names and positions. 
             // For that purpose we use the most derived member.
             var argumentAnalysis = AnalyzeArguments(member, arguments, isMethodGroupConversion, expanded: false);
+
+            // handle spread parameters
+            if (argumentAnalysis.HasSpreadParameters)
+                argumentAnalysis = AnalyzeSpreadArguments(member, arguments, argumentAnalysis, isMethodGroupConversion, ref useSiteDiagnostics);
+
             if (!argumentAnalysis.IsValid)
             {
                 switch (argumentAnalysis.Kind)
@@ -3159,6 +3188,161 @@ namespace Microsoft.CodeAnalysis.CSharp
             }
 
             return applicableResult;
+        }
+
+        private ArgumentAnalysisResult AnalyzeSpreadArguments(Symbol member, AnalyzedArguments arguments, ArgumentAnalysisResult argumentAnalysis, bool isMethodGroupConversion, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            var parameters = member.GetParameters();
+            var spreadArguments = ArrayBuilder<SpreadArgumentAnalysis>.GetInstance();
+
+            // we need to collect the parameter from the ones expected to be collected as spread parameters
+            for (var i = 0; i < arguments.Arguments.Count; i++)
+            {
+                var arg = arguments.Arguments[i];
+
+                // check if the argument should be "consumed" into the "spread arg"
+                var paramIndex = argumentAnalysis.ParameterFromArgument(i);
+                var param = parameters[paramIndex];
+                if (param.IsSpread && param.Type.Name != arg.Type.Name)
+                {
+                    // the argument is mapped to a spread parameter but is not the same type... so it should be part of the spread parameter instance
+                    // add a new spread argument holder
+                    SpreadArgumentAnalysis spreadArg = null;
+                    var spreadArgIndex = spreadArguments.FindIndex(a => a.ParameterIndex == paramIndex);
+                    if (spreadArgIndex != -1) spreadArg = spreadArguments[spreadArgIndex];
+
+                    if (spreadArg == null)
+                    {
+                        spreadArg = new SpreadArgumentAnalysis(paramIndex);
+                        spreadArguments.Add(spreadArg);
+                    }
+
+                    // we need the matching member in the spread type
+                    var argName = arguments.Name(i);
+                    var spreadArgMember = param.Type?.GetMembers().FirstOrDefault(m => m.Name == argName);
+
+                    // add the argument to the spread arg analysis ... it has a matching member, so we can initialize that member with the value of the argument
+                    if (spreadArgMember != null)
+                    {
+                        spreadArg.AddArgument(i);
+                    }
+                }
+            }
+
+            // now finalize the new collected arguments - consuming the parameters part of the spread - and injecting the parameters representing the spread
+
+            var newArguments = ArrayBuilder<BoundExpression>.GetInstance();
+            var newArgumentNames = ArrayBuilder<IdentifierNameSyntax>.GetInstance();
+            var newArgumentRefKinds = ArrayBuilder<RefKind>.GetInstance();
+            SyntheticBoundNodeFactory nodeFactory = null;
+
+            // now build tne new arguments in the order of 
+            for (var i = 0; i < parameters.Length; ++i)
+            {
+                // find matching argumnet
+                var param = parameters[i];
+
+                var argIndex = argumentAnalysis.ArgumentFromParameter(i);
+                if (argIndex == -1)
+                {
+                    // no matching argument for the parameter
+                    continue;
+                }
+
+                if (param.IsSpread)
+                {
+                    // check if it is any of the spread args
+                    var spreadArgIndex = spreadArguments.FindIndex(a => a.ParameterIndex == i);
+                    if (spreadArgIndex == -1) continue;
+
+                    nodeFactory ??= new SyntheticBoundNodeFactory(null, arguments.Arguments[0].Syntax.Parent, null, null);
+
+                    // we have a matching spread arg
+                    var spreadArgAnalysis = spreadArguments[spreadArgIndex];
+                    var spreadArg = BuildSpreadArg(member, spreadArgAnalysis, arguments, nodeFactory, ref useSiteDiagnostics);
+                    newArguments.Add(spreadArg);
+                    newArgumentNames.Add(SyntaxFactory.IdentifierName(parameters[i].Name));
+                    newArgumentRefKinds.Add(RefKind.None);
+                }
+                else
+                {
+                    // get the argument - so just add the new argument
+                    var arg = arguments.Argument(argIndex);
+                    newArguments.Add(arg);
+                    newArgumentNames.Add(arguments.NameSyntax(argIndex));
+                    newArgumentRefKinds.Add(arguments.RefKind(argIndex));
+                }
+            }
+
+            var newAnalyzedArguments = AnalyzedArguments.GetInstance(
+                newArguments.ToImmutableAndFree(),
+                newArgumentRefKinds.ToImmutableAndFree(),
+                newArgumentNames.ToImmutableAndFree()
+            );
+
+            // finally free the spread args
+            for (var i = 0; i < spreadArguments.Count; ++i)
+                spreadArguments[i].Free();
+            spreadArguments.Free();
+
+            // we now have the new arguments available - replace the argumnet analysis
+            var newArgumentAnalysis = AnalyzeArguments(member, newAnalyzedArguments, isMethodGroupConversion, expanded: false);
+            if (newArgumentAnalysis.IsValid)
+            {
+                // we have successfully bound the old arguments to new spread args - upating the initial analysis will overwrite it's internals...
+                argumentAnalysis = newArgumentAnalysis;
+                arguments.UpdateFrom(newAnalyzedArguments);
+            }
+
+            // free the new analyzed arguments
+            newAnalyzedArguments.Free();
+
+            return argumentAnalysis;
+        }
+
+        private BoundExpression BuildSpreadArg(Symbol symbol, SpreadArgumentAnalysis spreadArgAnalysis, AnalyzedArguments arguments, SyntheticBoundNodeFactory nodeFactory, ref HashSet<DiagnosticInfo> useSiteDiagnostics)
+        {
+            var parameters = symbol.GetParameters();
+            var spreadParam = parameters[spreadArgAnalysis.ParameterIndex];
+            var spreadTypeMembers = spreadParam.Type.GetMembersUnordered();
+
+            var initExpressions = ArrayBuilder<BoundExpression>.GetInstance();
+
+            // we need the implicit reciever
+            var implicitReceiver = new BoundObjectOrCollectionValuePlaceholder(SyntaxFactory.IdentifierName(spreadParam.Type.Name), spreadParam.Type) { WasCompilerGenerated = true };
+
+            // build the member initializer expressions
+            for (var i = 0; i < spreadArgAnalysis.Arguments.Count; ++i)
+            {
+                var argIndex = spreadArgAnalysis.Arguments[i];
+                var arg = arguments.Argument(argIndex);
+                var argName = arguments.Name(argIndex);
+
+                // add a member initializer expression for the arg ... to the matching member
+                var argMember = spreadTypeMembers.FirstOrDefault(m => m.Name == argName);
+                if (argMember == null)
+                {
+                    // error ... must match a member to be part of the spread ...
+                    continue;
+                }
+
+                var diagnostics = DiagnosticBag.GetInstance();
+                var boundMemberAccess = _binder.BindSimpleObjectInitializerMember(implicitReceiver, SyntaxFactory.IdentifierName(argName), arg, diagnostics);
+                var boundMemberInitializerExpr = _binder.BindAssignment(arg.Syntax, boundMemberAccess, arg, isRef: false, diagnostics);
+                if (diagnostics.Count > 0)
+                {
+                    if (useSiteDiagnostics == null)
+                        useSiteDiagnostics = new HashSet<DiagnosticInfo>();
+                    useSiteDiagnostics.AddAll(diagnostics.AsEnumerable().Cast<DiagnosticWithInfo>().Select(d => d.Info));
+                }
+                diagnostics.Free();
+
+                initExpressions.Add(boundMemberInitializerExpr);
+            }
+
+            // new instance of the parameter type with an object initializer
+            var initializer = nodeFactory.ObjectInitializer(implicitReceiver, spreadParam.Type, initExpressions.ToImmutableAndFree(), arguments.Argument(0).Syntax.Parent);
+            return nodeFactory.New((NamedTypeSymbol)spreadParam.Type).UpdateInitializer(initializer);
         }
 
         private MemberResolutionResult<TMember> IsMemberApplicableInExpandedForm<TMember>(

--- a/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
+++ b/src/Compilers/CSharp/Portable/Binder/Semantics/OverloadResolution/OverloadResolution_ArgsToParameters.cs
@@ -384,22 +384,9 @@ namespace Microsoft.CodeAnalysis.CSharp
                 }
             }
 
-            // if now matching named parameter, we can try with the spread parameters
-            for (int p = 0; p < memberParameters.Length; ++p)
-            {
-                var param = memberParameters[p];
-                if (!param.IsSpread) continue;
-
-                // match the parameter to the spread
-                var spreadMember = param.Type?.GetMembers().FirstOrDefault(m => m.Name == name);
-                if (spreadMember != null)
-                {
-                    isSpread = true;
-                    return p;
-                }
-            }
-
-            return null;
+            var (_, pi) = SpreadParamHelpers.GetFirstMatchingSpreadParam(memberParameters, name);
+            isSpread = pi != null;
+            return pi;
         }
 
         private static int? CorrespondsToAnyParameter(

--- a/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
+++ b/src/Compilers/CSharp/Portable/BoundTree/BoundExpression.cs
@@ -454,6 +454,21 @@ namespace Microsoft.CodeAnalysis.CSharp
                 binderOpt: BinderOpt,
                 type: changeTypeOpt ?? Type);
         }
+
+        internal BoundObjectCreationExpression UpdateInitializer(BoundObjectInitializerExpressionBase? newInitializerExpression)
+        {
+            return Update(
+                constructor: Constructor,
+                arguments: Arguments,
+                argumentNamesOpt: ArgumentNamesOpt,
+                argumentRefKindsOpt: ArgumentRefKindsOpt,
+                expanded: Expanded,
+                argsToParamsOpt: ArgsToParamsOpt,
+                constantValueOpt: ConstantValueOpt,
+                initializerExpressionOpt: newInitializerExpression,
+                binderOpt: BinderOpt,
+                type: Type);
+        }
     }
 
     internal partial class BoundAnonymousObjectCreationExpression

--- a/src/Compilers/CSharp/Portable/CSharpResources.resx
+++ b/src/Compilers/CSharp/Portable/CSharpResources.resx
@@ -6436,4 +6436,7 @@ To remove the warning, you can use /reference instead (set the Embed Interop Typ
   <data name="IDS_FeatureExtensionGetEnumerator" xml:space="preserve">
     <value>extension GetEnumerator</value>
   </data>
+  <data name="ERR_DefaultConstructorRequiredForSpreadParam" xml:space="preserve">
+    <value>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</value>
+  </data>
 </root>

--- a/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
+++ b/src/Compilers/CSharp/Portable/Errors/ErrorCode.cs
@@ -1887,5 +1887,9 @@ namespace Microsoft.CodeAnalysis.CSharp
 
         #endregion diagnostics introduced for C# 9.0
         // Note: you will need to re-generate compiler code after adding warnings (eng\generate-compiler-code.cmd)
+
+        #region diagnostics for rapid sharp
+        ERR_DefaultConstructorRequiredForSpreadParam = 9000,
+        #endregion
     }
 }

--- a/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
+++ b/src/Compilers/CSharp/Portable/Generated/CSharp.Generated.g4
@@ -159,7 +159,7 @@ parameter_list
   ;
 
 parameter
-  : attribute_list* modifier* (identifier_token | '__arglist') type? equals_value_clause?
+  : attribute_list* modifier* (identifier_token | '__arglist') '...'? type? equals_value_clause?
   ;
 
 constructor_initializer

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Internal.Generated.cs
@@ -26955,13 +26955,14 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         internal readonly GreenNode? attributeLists;
         internal readonly GreenNode? modifiers;
         internal readonly SyntaxToken identifier;
+        internal readonly SyntaxToken? spread;
         internal readonly TypeSyntax? type;
         internal readonly EqualsValueClauseSyntax? @default;
 
-        internal ParameterSyntax(SyntaxKind kind, GreenNode? attributeLists, GreenNode? modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
+        internal ParameterSyntax(SyntaxKind kind, GreenNode? attributeLists, GreenNode? modifiers, SyntaxToken identifier, SyntaxToken? spread, TypeSyntax? type, EqualsValueClauseSyntax? @default, DiagnosticInfo[]? diagnostics, SyntaxAnnotation[]? annotations)
           : base(kind, diagnostics, annotations)
         {
-            this.SlotCount = 5;
+            this.SlotCount = 6;
             if (attributeLists != null)
             {
                 this.AdjustFlagsAndWidth(attributeLists);
@@ -26974,6 +26975,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(identifier);
             this.identifier = identifier;
+            if (spread != null)
+            {
+                this.AdjustFlagsAndWidth(spread);
+                this.spread = spread;
+            }
             if (type != null)
             {
                 this.AdjustFlagsAndWidth(type);
@@ -26986,11 +26992,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        internal ParameterSyntax(SyntaxKind kind, GreenNode? attributeLists, GreenNode? modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default, SyntaxFactoryContext context)
+        internal ParameterSyntax(SyntaxKind kind, GreenNode? attributeLists, GreenNode? modifiers, SyntaxToken identifier, SyntaxToken? spread, TypeSyntax? type, EqualsValueClauseSyntax? @default, SyntaxFactoryContext context)
           : base(kind)
         {
             this.SetFactoryContext(context);
-            this.SlotCount = 5;
+            this.SlotCount = 6;
             if (attributeLists != null)
             {
                 this.AdjustFlagsAndWidth(attributeLists);
@@ -27003,6 +27009,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(identifier);
             this.identifier = identifier;
+            if (spread != null)
+            {
+                this.AdjustFlagsAndWidth(spread);
+                this.spread = spread;
+            }
             if (type != null)
             {
                 this.AdjustFlagsAndWidth(type);
@@ -27015,10 +27026,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
         }
 
-        internal ParameterSyntax(SyntaxKind kind, GreenNode? attributeLists, GreenNode? modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default)
+        internal ParameterSyntax(SyntaxKind kind, GreenNode? attributeLists, GreenNode? modifiers, SyntaxToken identifier, SyntaxToken? spread, TypeSyntax? type, EqualsValueClauseSyntax? @default)
           : base(kind)
         {
-            this.SlotCount = 5;
+            this.SlotCount = 6;
             if (attributeLists != null)
             {
                 this.AdjustFlagsAndWidth(attributeLists);
@@ -27031,6 +27042,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             }
             this.AdjustFlagsAndWidth(identifier);
             this.identifier = identifier;
+            if (spread != null)
+            {
+                this.AdjustFlagsAndWidth(spread);
+                this.spread = spread;
+            }
             if (type != null)
             {
                 this.AdjustFlagsAndWidth(type);
@@ -27049,6 +27065,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> Modifiers => new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken>(this.modifiers);
         /// <summary>Gets the identifier.</summary>
         public SyntaxToken Identifier => this.identifier;
+        public SyntaxToken? Spread => this.spread;
         public TypeSyntax? Type => this.type;
         public EqualsValueClauseSyntax? Default => this.@default;
 
@@ -27058,8 +27075,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 0 => this.attributeLists,
                 1 => this.modifiers,
                 2 => this.identifier,
-                3 => this.type,
-                4 => this.@default,
+                3 => this.spread,
+                4 => this.type,
+                5 => this.@default,
                 _ => null,
             };
 
@@ -27068,11 +27086,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         public override void Accept(CSharpSyntaxVisitor visitor) => visitor.VisitParameter(this);
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitParameter(this);
 
-        public ParameterSyntax Update(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken identifier, TypeSyntax type, EqualsValueClauseSyntax @default)
+        public ParameterSyntax Update(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken identifier, SyntaxToken spread, TypeSyntax type, EqualsValueClauseSyntax @default)
         {
-            if (attributeLists != this.AttributeLists || modifiers != this.Modifiers || identifier != this.Identifier || type != this.Type || @default != this.Default)
+            if (attributeLists != this.AttributeLists || modifiers != this.Modifiers || identifier != this.Identifier || spread != this.Spread || type != this.Type || @default != this.Default)
             {
-                var newNode = SyntaxFactory.Parameter(attributeLists, modifiers, identifier, type, @default);
+                var newNode = SyntaxFactory.Parameter(attributeLists, modifiers, identifier, spread, type, @default);
                 var diags = GetDiagnostics();
                 if (diags?.Length > 0)
                     newNode = newNode.WithDiagnosticsGreen(diags);
@@ -27086,15 +27104,15 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         }
 
         internal override GreenNode SetDiagnostics(DiagnosticInfo[]? diagnostics)
-            => new ParameterSyntax(this.Kind, this.attributeLists, this.modifiers, this.identifier, this.type, this.@default, diagnostics, GetAnnotations());
+            => new ParameterSyntax(this.Kind, this.attributeLists, this.modifiers, this.identifier, this.spread, this.type, this.@default, diagnostics, GetAnnotations());
 
         internal override GreenNode SetAnnotations(SyntaxAnnotation[]? annotations)
-            => new ParameterSyntax(this.Kind, this.attributeLists, this.modifiers, this.identifier, this.type, this.@default, GetDiagnostics(), annotations);
+            => new ParameterSyntax(this.Kind, this.attributeLists, this.modifiers, this.identifier, this.spread, this.type, this.@default, GetDiagnostics(), annotations);
 
         internal ParameterSyntax(ObjectReader reader)
           : base(reader)
         {
-            this.SlotCount = 5;
+            this.SlotCount = 6;
             var attributeLists = (GreenNode?)reader.ReadValue();
             if (attributeLists != null)
             {
@@ -27110,6 +27128,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             var identifier = (SyntaxToken)reader.ReadValue();
             AdjustFlagsAndWidth(identifier);
             this.identifier = identifier;
+            var spread = (SyntaxToken?)reader.ReadValue();
+            if (spread != null)
+            {
+                AdjustFlagsAndWidth(spread);
+                this.spread = spread;
+            }
             var type = (TypeSyntax?)reader.ReadValue();
             if (type != null)
             {
@@ -27130,6 +27154,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             writer.WriteValue(this.attributeLists);
             writer.WriteValue(this.modifiers);
             writer.WriteValue(this.identifier);
+            writer.WriteValue(this.spread);
             writer.WriteValue(this.type);
             writer.WriteValue(this.@default);
         }
@@ -33879,7 +33904,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             => node.Update((SyntaxToken)Visit(node.OpenBracketToken), VisitList(node.Parameters), (SyntaxToken)Visit(node.CloseBracketToken));
 
         public override CSharpSyntaxNode VisitParameter(ParameterSyntax node)
-            => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), (SyntaxToken)Visit(node.Identifier), (TypeSyntax)Visit(node.Type), (EqualsValueClauseSyntax)Visit(node.Default));
+            => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), (SyntaxToken)Visit(node.Identifier), (SyntaxToken)Visit(node.Spread), (TypeSyntax)Visit(node.Type), (EqualsValueClauseSyntax)Visit(node.Default));
 
         public override CSharpSyntaxNode VisitIncompleteMember(IncompleteMemberSyntax node)
             => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), (TypeSyntax)Visit(node.Type));
@@ -38088,7 +38113,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public ParameterSyntax Parameter(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default)
+        public ParameterSyntax Parameter(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken identifier, SyntaxToken? spread, TypeSyntax? type, EqualsValueClauseSyntax? @default)
         {
 #if DEBUG
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -38098,9 +38123,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case SyntaxKind.ArgListKeyword: break;
                 default: throw new ArgumentException(nameof(identifier));
             }
+            if (spread != null)
+            {
+                switch (spread.Kind)
+                {
+                    case SyntaxKind.DotDotDotToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(spread));
+                }
+            }
 #endif
 
-            return new ParameterSyntax(SyntaxKind.Parameter, attributeLists.Node, modifiers.Node, identifier, type, @default, this.context);
+            return new ParameterSyntax(SyntaxKind.Parameter, attributeLists.Node, modifiers.Node, identifier, spread, type, @default, this.context);
         }
 
         public IncompleteMemberSyntax IncompleteMember(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, TypeSyntax? type)
@@ -43003,7 +43037,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
             return result;
         }
 
-        public static ParameterSyntax Parameter(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default)
+        public static ParameterSyntax Parameter(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, SyntaxToken identifier, SyntaxToken? spread, TypeSyntax? type, EqualsValueClauseSyntax? @default)
         {
 #if DEBUG
             if (identifier == null) throw new ArgumentNullException(nameof(identifier));
@@ -43013,9 +43047,18 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                 case SyntaxKind.ArgListKeyword: break;
                 default: throw new ArgumentException(nameof(identifier));
             }
+            if (spread != null)
+            {
+                switch (spread.Kind)
+                {
+                    case SyntaxKind.DotDotDotToken:
+                    case SyntaxKind.None: break;
+                    default: throw new ArgumentException(nameof(spread));
+                }
+            }
 #endif
 
-            return new ParameterSyntax(SyntaxKind.Parameter, attributeLists.Node, modifiers.Node, identifier, type, @default);
+            return new ParameterSyntax(SyntaxKind.Parameter, attributeLists.Node, modifiers.Node, identifier, spread, type, @default);
         }
 
         public static IncompleteMemberSyntax IncompleteMember(Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<AttributeListSyntax> attributeLists, Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<SyntaxToken> modifiers, TypeSyntax? type)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Main.Generated.cs
@@ -2160,7 +2160,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => node.Update(VisitToken(node.OpenBracketToken), VisitList(node.Parameters), VisitToken(node.CloseBracketToken));
 
         public override SyntaxNode? VisitParameter(ParameterSyntax node)
-            => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), VisitToken(node.Identifier), (TypeSyntax?)Visit(node.Type), (EqualsValueClauseSyntax?)Visit(node.Default));
+            => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), VisitToken(node.Identifier), VisitToken(node.Spread), (TypeSyntax?)Visit(node.Type), (EqualsValueClauseSyntax?)Visit(node.Default));
 
         public override SyntaxNode? VisitIncompleteMember(IncompleteMemberSyntax node)
             => node.Update(VisitList(node.AttributeLists), VisitList(node.Modifiers), (TypeSyntax?)Visit(node.Type));
@@ -5683,7 +5683,7 @@ namespace Microsoft.CodeAnalysis.CSharp
             => SyntaxFactory.BracketedParameterList(SyntaxFactory.Token(SyntaxKind.OpenBracketToken), parameters, SyntaxFactory.Token(SyntaxKind.CloseBracketToken));
 
         /// <summary>Creates a new ParameterSyntax instance.</summary>
-        public static ParameterSyntax Parameter(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default)
+        public static ParameterSyntax Parameter(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken identifier, SyntaxToken spread, TypeSyntax? type, EqualsValueClauseSyntax? @default)
         {
             switch (identifier.Kind())
             {
@@ -5691,12 +5691,22 @@ namespace Microsoft.CodeAnalysis.CSharp
                 case SyntaxKind.ArgListKeyword: break;
                 default: throw new ArgumentException(nameof(identifier));
             }
-            return (ParameterSyntax)Syntax.InternalSyntax.SyntaxFactory.Parameter(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), modifiers.Node.ToGreenList<Syntax.InternalSyntax.SyntaxToken>(), (Syntax.InternalSyntax.SyntaxToken)identifier.Node!, type == null ? null : (Syntax.InternalSyntax.TypeSyntax)type.Green, @default == null ? null : (Syntax.InternalSyntax.EqualsValueClauseSyntax)@default.Green).CreateRed();
+            switch (spread.Kind())
+            {
+                case SyntaxKind.DotDotDotToken:
+                case SyntaxKind.None: break;
+                default: throw new ArgumentException(nameof(spread));
+            }
+            return (ParameterSyntax)Syntax.InternalSyntax.SyntaxFactory.Parameter(attributeLists.Node.ToGreenList<Syntax.InternalSyntax.AttributeListSyntax>(), modifiers.Node.ToGreenList<Syntax.InternalSyntax.SyntaxToken>(), (Syntax.InternalSyntax.SyntaxToken)identifier.Node!, (Syntax.InternalSyntax.SyntaxToken?)spread.Node, type == null ? null : (Syntax.InternalSyntax.TypeSyntax)type.Green, @default == null ? null : (Syntax.InternalSyntax.EqualsValueClauseSyntax)@default.Green).CreateRed();
         }
 
         /// <summary>Creates a new ParameterSyntax instance.</summary>
+        public static ParameterSyntax Parameter(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default)
+            => SyntaxFactory.Parameter(attributeLists, modifiers, identifier, default, type, @default);
+
+        /// <summary>Creates a new ParameterSyntax instance.</summary>
         public static ParameterSyntax Parameter(SyntaxToken identifier)
-            => SyntaxFactory.Parameter(default, default(SyntaxTokenList), identifier, default, default);
+            => SyntaxFactory.Parameter(default, default(SyntaxTokenList), identifier, default, default, default);
 
         /// <summary>Creates a new IncompleteMemberSyntax instance.</summary>
         public static IncompleteMemberSyntax IncompleteMember(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, TypeSyntax? type)

--- a/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
+++ b/src/Compilers/CSharp/Portable/Generated/Syntax.xml.Syntax.Generated.cs
@@ -11784,16 +11784,25 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         /// <summary>Gets the identifier.</summary>
         public SyntaxToken Identifier => new SyntaxToken(this, ((Syntax.InternalSyntax.ParameterSyntax)this.Green).identifier, GetChildPosition(2), GetChildIndex(2));
 
-        public TypeSyntax? Type => GetRed(ref this.type, 3);
+        public SyntaxToken Spread
+        {
+            get
+            {
+                var slot = ((Syntax.InternalSyntax.ParameterSyntax)this.Green).spread;
+                return slot != null ? new SyntaxToken(this, slot, GetChildPosition(3), GetChildIndex(3)) : default;
+            }
+        }
 
-        public EqualsValueClauseSyntax? Default => GetRed(ref this.@default, 4);
+        public TypeSyntax? Type => GetRed(ref this.type, 4);
+
+        public EqualsValueClauseSyntax? Default => GetRed(ref this.@default, 5);
 
         internal override SyntaxNode? GetNodeSlot(int index)
             => index switch
             {
                 0 => GetRedAtZero(ref this.attributeLists)!,
-                3 => GetRed(ref this.type, 3),
-                4 => GetRed(ref this.@default, 4),
+                4 => GetRed(ref this.type, 4),
+                5 => GetRed(ref this.@default, 5),
                 _ => null,
             };
 
@@ -11801,8 +11810,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             => index switch
             {
                 0 => this.attributeLists,
-                3 => this.type,
-                4 => this.@default,
+                4 => this.type,
+                5 => this.@default,
                 _ => null,
             };
 
@@ -11810,11 +11819,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
         [return: MaybeNull]
         public override TResult Accept<TResult>(CSharpSyntaxVisitor<TResult> visitor) => visitor.VisitParameter(this);
 
-        public ParameterSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken identifier, TypeSyntax? type, EqualsValueClauseSyntax? @default)
+        public ParameterSyntax Update(SyntaxList<AttributeListSyntax> attributeLists, SyntaxTokenList modifiers, SyntaxToken identifier, SyntaxToken spread, TypeSyntax? type, EqualsValueClauseSyntax? @default)
         {
-            if (attributeLists != this.AttributeLists || modifiers != this.Modifiers || identifier != this.Identifier || type != this.Type || @default != this.Default)
+            if (attributeLists != this.AttributeLists || modifiers != this.Modifiers || identifier != this.Identifier || spread != this.Spread || type != this.Type || @default != this.Default)
             {
-                var newNode = SyntaxFactory.Parameter(attributeLists, modifiers, identifier, type, @default);
+                var newNode = SyntaxFactory.Parameter(attributeLists, modifiers, identifier, spread, type, @default);
                 var annotations = GetAnnotations();
                 return annotations?.Length > 0 ? newNode.WithAnnotations(annotations) : newNode;
             }
@@ -11822,11 +11831,12 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax
             return this;
         }
 
-        public ParameterSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.Modifiers, this.Identifier, this.Type, this.Default);
-        public ParameterSyntax WithModifiers(SyntaxTokenList modifiers) => Update(this.AttributeLists, modifiers, this.Identifier, this.Type, this.Default);
-        public ParameterSyntax WithIdentifier(SyntaxToken identifier) => Update(this.AttributeLists, this.Modifiers, identifier, this.Type, this.Default);
-        public ParameterSyntax WithType(TypeSyntax? type) => Update(this.AttributeLists, this.Modifiers, this.Identifier, type, this.Default);
-        public ParameterSyntax WithDefault(EqualsValueClauseSyntax? @default) => Update(this.AttributeLists, this.Modifiers, this.Identifier, this.Type, @default);
+        public ParameterSyntax WithAttributeLists(SyntaxList<AttributeListSyntax> attributeLists) => Update(attributeLists, this.Modifiers, this.Identifier, this.Spread, this.Type, this.Default);
+        public ParameterSyntax WithModifiers(SyntaxTokenList modifiers) => Update(this.AttributeLists, modifiers, this.Identifier, this.Spread, this.Type, this.Default);
+        public ParameterSyntax WithIdentifier(SyntaxToken identifier) => Update(this.AttributeLists, this.Modifiers, identifier, this.Spread, this.Type, this.Default);
+        public ParameterSyntax WithSpread(SyntaxToken spread) => Update(this.AttributeLists, this.Modifiers, this.Identifier, spread, this.Type, this.Default);
+        public ParameterSyntax WithType(TypeSyntax? type) => Update(this.AttributeLists, this.Modifiers, this.Identifier, this.Spread, type, this.Default);
+        public ParameterSyntax WithDefault(EqualsValueClauseSyntax? @default) => Update(this.AttributeLists, this.Modifiers, this.Identifier, this.Spread, this.Type, @default);
 
         public ParameterSyntax AddAttributeLists(params AttributeListSyntax[] items) => WithAttributeLists(this.AttributeLists.AddRange(items));
         public ParameterSyntax AddModifiers(params SyntaxToken[] items) => WithModifiers(this.Modifiers.AddRange(items));

--- a/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
+++ b/src/Compilers/CSharp/Portable/Lowering/SyntheticBoundNodeFactory.cs
@@ -623,6 +623,13 @@ namespace Microsoft.CodeAnalysis.CSharp
             return New(ctor, args);
         }
 
+        public BoundObjectCreationExpression TryNew(NamedTypeSymbol type, params BoundExpression[] args)
+        {
+            var ctor = type.InstanceConstructors.FirstOrDefault(c => c.ParameterCount == args.Length);
+            if (ctor == null) return null;
+            return New(ctor, args);
+        }
+
         public BoundObjectCreationExpression New(NamedTypeSymbol type, SyntaxNode syntax, params BoundExpression[] args)
         {
             var ctor = type.InstanceConstructors.Single(c => c.ParameterCount == args.Length);

--- a/src/Compilers/CSharp/Portable/Parser/Lexer.cs
+++ b/src/Compilers/CSharp/Portable/Parser/Lexer.cs
@@ -464,13 +464,13 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
                             TextWindow.AdvanceChar();
                             if (TextWindow.PeekChar() == '.')
                             {
-                                // Triple-dot: explicitly reject this, to allow triple-dot
-                                // to be added to the language without a breaking change.
-                                // (without this, 0...2 would parse as (0)..(.2), i.e. a range from 0 to 0.2)
-                                this.AddError(ErrorCode.ERR_TripleDotNotAllowed);
+                                TextWindow.AdvanceChar();
+                                info.Kind = SyntaxKind.DotDotDotToken;
                             }
-
-                            info.Kind = SyntaxKind.DotDotToken;
+                            else
+                            {
+                                info.Kind = SyntaxKind.DotDotToken;
+                            }
                         }
                         else
                         {
@@ -3970,11 +3970,13 @@ top:
                     {
                         if (TextWindow.PeekChar() == '.')
                         {
-                            // See documentation in ScanSyntaxToken
-                            this.AddCrefError(ErrorCode.ERR_UnexpectedCharacter, ".");
+                            TextWindow.AdvanceChar();
+                            info.Kind = SyntaxKind.DotDotDotToken;
                         }
-
-                        info.Kind = SyntaxKind.DotDotToken;
+                        else
+                        {
+                            info.Kind = SyntaxKind.DotDotToken;
+                        }
                     }
                     else
                     {

--- a/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
+++ b/src/Compilers/CSharp/Portable/Parser/SyntaxParser.cs
@@ -294,6 +294,9 @@ namespace Microsoft.CodeAnalysis.CSharp.Syntax.InternalSyntax
         protected SyntaxKind CurrentKind => CurrentToken.Kind;
         protected SyntaxKind CurrentContextualKind => CurrentToken.ContextualKind;
 
+        protected SyntaxKind PeekKind => PeekToken(1).Kind;
+        protected SyntaxKind PeekContextualKind => PeekToken(1).ContextualKind;
+
         protected bool IsCurrentTokenEndOfFile
         {
             get => CurrentToken.Kind == SyntaxKind.EndOfFileToken;

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -1,6 +1,12 @@
 Microsoft.CodeAnalysis.CSharp.BoundConversionSyntaxNodeExtensions
 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode.FindToken(int position, bool findInsideTrivia = false, bool findInsideSkippedTrivia = false) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.CSharp.Conversion.IsConditionalExpression.get -> bool
+Microsoft.CodeAnalysis.CSharp.Symbols.SpreadParamHelpers
+Microsoft.CodeAnalysis.CSharp.Symbols.TypeCache
+Microsoft.CodeAnalysis.CSharp.Symbols.TypeCache.Add(Microsoft.CodeAnalysis.ITypeSymbol type) -> void
+Microsoft.CodeAnalysis.CSharp.Symbols.TypeCache.Free() -> void
+Microsoft.CodeAnalysis.CSharp.Symbols.TypeCache.TryGetMetadata<T>(string metadataId, Microsoft.CodeAnalysis.ITypeSymbol type, System.Func<Microsoft.CodeAnalysis.ITypeSymbol, T> getMetadataFn) -> T
+Microsoft.CodeAnalysis.CSharp.Symbols.TypeCache.TypeCache() -> void
 Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.AddModifiers(params Microsoft.CodeAnalysis.SyntaxToken[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax.WithModifiers(Microsoft.CodeAnalysis.SyntaxTokenList modifiers) -> Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousFunctionExpressionSyntax
 Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousMethodExpressionSyntax.AddModifiers(params Microsoft.CodeAnalysis.SyntaxToken[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousMethodExpressionSyntax
@@ -73,6 +79,8 @@ static Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(Microsoft.CodeAn
 static Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(Microsoft.CodeAnalysis.Text.SourceText text, Microsoft.CodeAnalysis.CSharp.CSharpParseOptions options, string path, System.Collections.Immutable.ImmutableDictionary<string, Microsoft.CodeAnalysis.ReportDiagnostic> diagnosticOptions, bool? isGeneratedCode, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.SyntaxTree
 static Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(string text, Microsoft.CodeAnalysis.CSharp.CSharpParseOptions options = null, string path = "", System.Text.Encoding encoding = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.CodeAnalysis.SyntaxTree
 static Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(string text, Microsoft.CodeAnalysis.CSharp.CSharpParseOptions options, string path, System.Text.Encoding encoding, System.Collections.Immutable.ImmutableDictionary<string, Microsoft.CodeAnalysis.ReportDiagnostic> diagnosticOptions, bool? isGeneratedCode, System.Threading.CancellationToken cancellationToken) -> Microsoft.CodeAnalysis.SyntaxTree
+static Microsoft.CodeAnalysis.CSharp.Symbols.SpreadParamHelpers.GetFirstPossibleSpreadParamMember(string name, Microsoft.CodeAnalysis.ITypeSymbol type, Microsoft.CodeAnalysis.CSharp.Symbols.TypeCache typeCache) -> Microsoft.CodeAnalysis.ISymbol
+static Microsoft.CodeAnalysis.CSharp.Symbols.SpreadParamHelpers.GetPossibleSpreadParamMembers(Microsoft.CodeAnalysis.ITypeSymbol type) -> System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.ISymbol>
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.AnonymousMethodExpression(Microsoft.CodeAnalysis.SyntaxTokenList modifiers, Microsoft.CodeAnalysis.SyntaxToken delegateKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.ParameterListSyntax parameterList, Microsoft.CodeAnalysis.CSharp.Syntax.BlockSyntax block, Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax expressionBody) -> Microsoft.CodeAnalysis.CSharp.Syntax.AnonymousMethodExpressionSyntax
 Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions.WithSyntaxTreeOptionsProvider(Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider provider) -> Microsoft.CodeAnalysis.CSharp.CSharpCompilationOptions
 static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.ArgumentList(Microsoft.CodeAnalysis.SeparatedSyntaxList<Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax> arguments, Microsoft.CodeAnalysis.CSharp.Syntax.ParenthesizedLambdaExpressionSyntax trailingLambdaBlock) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentListSyntax

--- a/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/CSharp/Portable/PublicAPI.Unshipped.txt
@@ -53,6 +53,7 @@ Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax.Update(Microsoft.C
 Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax.WithType(Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.VariableDeclaratorSyntax
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.ColonEqualsToken = 8223 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.DefaultConstraint = 9057 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
+Microsoft.CodeAnalysis.CSharp.SyntaxKind.DotDotDotToken = 8224 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.FnKeyword = 8445 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.ImportKeyword = 8385 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind
 Microsoft.CodeAnalysis.CSharp.SyntaxKind.LambdaFunctionType = 9034 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind

--- a/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/ParameterSymbol.cs
@@ -126,6 +126,11 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
         public abstract bool IsParams { get; }
 
         /// <summary>
+        /// Returns true if the parameter is declared as a spread parameter type.
+        /// </summary>
+        public virtual bool IsSpread { get; protected internal set; }
+
+        /// <summary>
         /// Returns true if the parameter is semantically optional.
         /// </summary>
         /// <remarks>

--- a/src/Compilers/CSharp/Portable/Symbols/PublicModel/ParameterSymbol.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/PublicModel/ParameterSymbol.cs
@@ -21,6 +21,8 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols.PublicModel
 
         internal override CSharp.Symbol UnderlyingSymbol => _underlying;
 
+        public bool IsSpread => _underlying.IsSpread;
+
         ITypeSymbol IParameterSymbol.Type
         {
             get

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -13,7 +13,7 @@ using Roslyn.Utilities;
 
 namespace Microsoft.CodeAnalysis.CSharp.Symbols
 {
-    internal static class ParameterHelpers
+    internal static partial class ParameterHelpers
     {
         public static ImmutableArray<ParameterSymbol> MakeParameters(
             Binder binder,
@@ -42,16 +42,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                         DiagnosticBag declarationDiagnostics) =>
                 {
                     var isSpread = syntax.Spread.Node != null;
-
-                    if (isSpread)
+                    if (isSpread && !SpreadParamHelpers.IsValidSpreadArgType(parameterType.Type))
                     {
-                        // validate the argumnet type
-                        var defaultConstructor = (parameterType.Type as NamedTypeSymbol)?.InstanceConstructors.FirstOrDefault(ctor => ctor.ParameterCount == 0);
-                        if (defaultConstructor == null)
-                        {
-                            // the parameter is invalid - spread arg types must have default public constructor
-                            diagnostics.Add(ErrorCode.ERR_DefaultConstructorRequiredForSpreadParam, syntax.Location, parameterType.Type.Name);
-                        }
+                        // the parameter is invalid - spread arg types must have default public constructor
+                        diagnostics.Add(ErrorCode.ERR_DefaultConstructorRequiredForSpreadParam, syntax.Location, parameterType.Type.Name);
                     }
 
                     var p = SourceParameterSymbol.Create(

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers.cs
@@ -40,7 +40,7 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                                         SyntaxToken paramsKeyword, SyntaxToken thisKeyword, bool addRefReadOnlyModifier,
                                         DiagnosticBag declarationDiagnostics) =>
                 {
-                    return SourceParameterSymbol.Create(
+                    var p = SourceParameterSymbol.Create(
                         context,
                         owner,
                         parameterType,
@@ -52,6 +52,10 @@ namespace Microsoft.CodeAnalysis.CSharp.Symbols
                         isExtensionMethodThis: ordinal == 0 && thisKeyword.Kind() != SyntaxKind.None,
                         addRefReadOnlyModifier,
                         declarationDiagnostics);
+
+                    p.IsSpread = syntax.Spread.Node != null;
+
+                    return p;
                 }
 );
         }

--- a/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers_SpreadParams.cs
+++ b/src/Compilers/CSharp/Portable/Symbols/Source/ParameterHelpers_SpreadParams.cs
@@ -1,0 +1,141 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.PooledObjects;
+using Roslyn.Utilities;
+
+namespace Microsoft.CodeAnalysis.CSharp.Symbols
+{
+    public class TypeCache
+    {
+        private Dictionary<string, Entry> _types;
+
+        public TypeCache()
+        {
+        }
+
+        public void Add(ITypeSymbol type)
+        {
+            if (_types == null) _types = new Dictionary<string, Entry>();
+
+            var id = type.ToString();
+            if (!_types.TryGetValue(id, out var entry))
+            {
+                entry = new Entry() { Type = type };
+                _types[id] = entry;
+            }
+        }
+
+        public T TryGetMetadata<T>(string metadataId, ITypeSymbol type, Func<ITypeSymbol, T> getMetadataFn)
+        {
+            Add(type);
+
+            var id = type.ToString();
+            var entry = _types[id];
+
+            return (T)(object)entry.TryGetMetadata(metadataId, getMetadataFn);
+        }
+
+        public void Free()
+        {
+            if (_types != null)
+            {
+                foreach (var entry in _types.Values)
+                    entry.Free();
+
+                _types.Clear();
+            }
+            _types = null;
+        }
+
+        class Entry
+        {
+            private Dictionary<string, object> _metadata;
+
+            public ITypeSymbol Type { get; set; }
+
+            public object TryGetMetadata<T>(string metadataId, Func<ITypeSymbol, T> getMetadataFn)
+            {
+                if (_metadata == null) _metadata = new Dictionary<string, object>();
+
+                if (!_metadata.TryGetValue(metadataId, out var value))
+                {
+                    value = getMetadataFn(Type);
+                    _metadata[metadataId] = value;
+                }
+
+                return value;
+            }
+
+            public void Free()
+            {
+                if (_metadata != null)
+                {
+                    _metadata.Clear();
+                    _metadata = null;
+                }
+
+                Type = null;
+            }
+        }
+    }
+
+    public static partial class SpreadParamHelpers
+    {
+        internal static bool IsValidSpreadArgType(TypeSymbol type)
+        {
+            // must have a default constructor
+            var defaultConstructor = (type as NamedTypeSymbol)?.InstanceConstructors.FirstOrDefault(ctor => ctor.ParameterCount == 0);
+            return defaultConstructor != null;
+        }
+
+        public static IEnumerable<ISymbol> GetPossibleSpreadParamMembers(ITypeSymbol type)
+        {
+            return type.GetMembers().Where(m => m.Kind == SymbolKind.Field || m.Kind == SymbolKind.Property);
+        }
+
+        internal static Symbol GetFirstPossibleSpreadParamMember(IEnumerable<Symbol> members, string name)
+        {
+            return members.FirstOrDefault(m => (m.Kind == SymbolKind.Field || m.Kind == SymbolKind.Property) && m.Name == name);
+        }
+
+        internal static ISymbol GetFirstPossibleSpreadParamMember(IEnumerable<ISymbol> members, string name)
+        {
+            return members.FirstOrDefault(m => (m.Kind == SymbolKind.Field || m.Kind == SymbolKind.Property) && m.Name == name);
+        }
+
+        internal static (Symbol, int?) GetFirstMatchingSpreadParam(ImmutableArray<ParameterSymbol> parameters, string name)
+        {
+            // if now matching named parameter, we can try with the spread parameters
+            for (int p = 0; p < parameters.Length; ++p)
+            {
+                var param = parameters[p];
+                if (!param.IsSpread) continue;
+
+                // match the parameter to the spread
+                var spreadMember = GetFirstPossibleSpreadParamMember(param.Type.GetMembers(), name);
+                if (spreadMember != null)
+                {
+                    return (param, p);
+                }
+            }
+
+            return (null, null);
+        }
+
+        public static ISymbol GetFirstPossibleSpreadParamMember(string name, ITypeSymbol type, TypeCache typeCache)
+        {
+            return typeCache.TryGetMetadata($"SpreadParamMember_{name}", type, t => {
+                return GetFirstPossibleSpreadParamMember(t.GetMembers(), name);
+            });
+        }
+    }
+}

--- a/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
+++ b/src/Compilers/CSharp/Portable/Syntax/Syntax.xml
@@ -4103,6 +4103,9 @@
       <Kind Name="IdentifierToken"/>
       <Kind Name="ArgListKeyword"/>
     </Field>
+    <Field Name="Spread" Type="SyntaxToken" Optional="true">
+      <Kind Name="DotDotDotToken"/>
+    </Field>
     <Field Name="Type" Type="TypeSyntax" Optional="true"/>
     <Field Name="Default" Type="EqualsValueClauseSyntax" Optional="true"/>
   </Node>

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKind.cs
@@ -44,6 +44,7 @@ namespace Microsoft.CodeAnalysis.CSharp
         SlashToken = 8221,
         DotDotToken = 8222,
         ColonEqualsToken = 8223,
+        DotDotDotToken = 8224,
 
         // additional xml tokens
         SlashGreaterThanToken = 8232, // xml empty element end

--- a/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
+++ b/src/Compilers/CSharp/Portable/Syntax/SyntaxKindFacts.cs
@@ -1445,6 +1445,8 @@ namespace Microsoft.CodeAnalysis.CSharp
                     return "??=";
                 case SyntaxKind.DotDotToken:
                     return "..";
+                case SyntaxKind.DotDotDotToken:
+                    return "...";
 
                 // Keywords
                 case SyntaxKind.BoolKeyword:

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.cs.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">Typ {0} nemůže být vložený, protože má neabstraktní člen. Zvažte nastavení vlastnosti Vložit typy spolupráce na hodnotu false.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.de.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">Der Typ "{0}" kann nicht eingebettet werden, weil er einen nicht abstrakten Member aufweist. Legen Sie die Eigenschaft "Interoptypen einbetten" ggf. auf FALSE fest.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.es.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">El tipo "{0}" no se puede incrustar porque tiene un miembro no abstracto. Puede establecer la propiedad "Incrustar tipos de interoperabilidad" en false.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.fr.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">Impossible d'incorporer le type '{0}', car il a un membre non abstrait. Affectez la valeur false à la propriété 'Incorporer les types interop'.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.it.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">Non è possibile incorporare il tipo '{0}' perché contiene un membro non astratto. Provare a impostare la proprietà 'Incorpora tipi di interoperabilità' su false.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ja.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">型 '{0}' には非抽象メンバーがあるため、この型を埋め込むことはできません。'相互運用型の埋め込み' プロパティを false に設定することをご検討ください。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ko.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">'{0}' 형식에는 비추상 멤버가 있으므로 해당 형식을 포함할 수 없습니다. 'Interop 형식 포함' 속성을 false로 설정해보세요.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pl.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">Nie można osadzić typu „{0}”, ponieważ ma nieabstrakcyjną składową. Rozważ ustawienie wartości false dla właściwości „Osadź typy międzyoperacyjne”.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.pt-BR.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">O tipo '{0}' não pode ser inserido porque tem um membro que não é abstrato. Considere a definição da propriedade 'Inserir Tipos de Interoperabilidade' como false.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.ru.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">Не удается внедрить тип "{0}", так как он имеет неабстрактный член. Попробуйте задать для свойства "Внедрить типы взаимодействия" значение false.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.tr.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">{0}' türünün soyut olmayan bir üyesi olduğundan bu tür eklenemiyor. 'Embed Interop Types' özelliğini false olarak ayarlamayı deneyin.</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hans.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">无法嵌入类型“{0}”，因为它有非抽象成员。请考虑将“嵌入互操作类型”属性设置为 false。</target>

--- a/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
+++ b/src/Compilers/CSharp/Portable/xlf/CSharpResources.zh-Hant.xlf
@@ -222,6 +222,11 @@
         <target state="new">The 'default' constraint is valid on override and explicit interface implementation methods only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ERR_DefaultConstructorRequiredForSpreadParam">
+        <source>Type '{0}' must have public parameterless default constructor to be used as spread input parameter</source>
+        <target state="new">Type '{0}' must have public parameterless default constructor to be used as spread input parameter</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ERR_DefaultInterfaceImplementationInNoPIAType">
         <source>Type '{0}' cannot be embedded because it has a non-abstract member. Consider setting the 'Embed Interop Types' property to false.</source>
         <target state="translated">因為類型 '{0}' 有非抽象成員，所以無法內嵌。請考慮將 [內嵌 Interop 類型] 屬性設為 false。</target>

--- a/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
+++ b/src/Compilers/CSharp/Test/Syntax/Generated/Syntax.Test.xml.Generated.cs
@@ -560,7 +560,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => InternalSyntaxFactory.BracketedParameterList(InternalSyntaxFactory.Token(SyntaxKind.OpenBracketToken), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SeparatedSyntaxList<Syntax.InternalSyntax.ParameterSyntax>(), InternalSyntaxFactory.Token(SyntaxKind.CloseBracketToken));
 
         private static Syntax.InternalSyntax.ParameterSyntax GenerateParameter()
-            => InternalSyntaxFactory.Parameter(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.SyntaxToken>(), InternalSyntaxFactory.Identifier("Identifier"), null, null);
+            => InternalSyntaxFactory.Parameter(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.SyntaxToken>(), InternalSyntaxFactory.Identifier("Identifier"), null, null, null);
 
         private static Syntax.InternalSyntax.IncompleteMemberSyntax GenerateIncompleteMember()
             => InternalSyntaxFactory.IncompleteMember(new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.AttributeListSyntax>(), new Microsoft.CodeAnalysis.Syntax.InternalSyntax.SyntaxList<Syntax.InternalSyntax.SyntaxToken>(), null);
@@ -3053,6 +3053,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind);
+            Assert.Null(node.Spread);
             Assert.Null(node.Type);
             Assert.Null(node.Default);
 
@@ -10072,7 +10073,7 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             => SyntaxFactory.BracketedParameterList(SyntaxFactory.Token(SyntaxKind.OpenBracketToken), new SeparatedSyntaxList<ParameterSyntax>(), SyntaxFactory.Token(SyntaxKind.CloseBracketToken));
 
         private static ParameterSyntax GenerateParameter()
-            => SyntaxFactory.Parameter(new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), SyntaxFactory.Identifier("Identifier"), default(TypeSyntax), default(EqualsValueClauseSyntax));
+            => SyntaxFactory.Parameter(new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), SyntaxFactory.Identifier("Identifier"), default(SyntaxToken), default(TypeSyntax), default(EqualsValueClauseSyntax));
 
         private static IncompleteMemberSyntax GenerateIncompleteMember()
             => SyntaxFactory.IncompleteMember(new SyntaxList<AttributeListSyntax>(), new SyntaxTokenList(), default(TypeSyntax));
@@ -12565,9 +12566,10 @@ namespace Microsoft.CodeAnalysis.CSharp.UnitTests
             Assert.Equal(default, node.AttributeLists);
             Assert.Equal(default, node.Modifiers);
             Assert.Equal(SyntaxKind.IdentifierToken, node.Identifier.Kind());
+            Assert.Equal(SyntaxKind.None, node.Spread.Kind());
             Assert.Null(node.Type);
             Assert.Null(node.Default);
-            var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithIdentifier(node.Identifier).WithType(node.Type).WithDefault(node.Default);
+            var newNode = node.WithAttributeLists(node.AttributeLists).WithModifiers(node.Modifiers).WithIdentifier(node.Identifier).WithSpread(node.Spread).WithType(node.Type).WithDefault(node.Default);
             Assert.Equal(node, newNode);
         }
 

--- a/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
+++ b/src/Compilers/Core/Portable/Compilation/SymbolInfo.cs
@@ -27,6 +27,11 @@ namespace Microsoft.CodeAnalysis
         public ISymbol? Symbol { get; }
 
         /// <summary>
+        /// If the symbol is refering to a parameter and it's a spread parameter type
+        /// </summary>
+        public bool IsSpreadParam { get; }
+
+        /// <summary>
         /// If the expression did not successfully resolve to a symbol, but there were one or more
         /// symbols that may have been considered but discarded, this property returns those
         /// symbols. The reason that the symbols did not successfully resolve to a symbol are
@@ -60,22 +65,22 @@ namespace Microsoft.CodeAnalysis
         /// </summary>
         public CandidateReason CandidateReason { get; }
 
-        internal SymbolInfo(ISymbol symbol)
-            : this(symbol, ImmutableArray<ISymbol>.Empty, CandidateReason.None)
+        internal SymbolInfo(ISymbol symbol, bool isSpreadParam = false)
+            : this(symbol, ImmutableArray<ISymbol>.Empty, CandidateReason.None, isSpreadParam)
         {
         }
 
-        internal SymbolInfo(ISymbol symbol, CandidateReason reason)
-            : this(symbol, ImmutableArray<ISymbol>.Empty, reason)
+        internal SymbolInfo(ISymbol symbol, CandidateReason reason, bool isSpreadParam = false)
+            : this(symbol, ImmutableArray<ISymbol>.Empty, reason, isSpreadParam)
         {
         }
 
-        internal SymbolInfo(ImmutableArray<ISymbol> candidateSymbols, CandidateReason candidateReason)
-            : this(null, candidateSymbols, candidateReason)
+        internal SymbolInfo(ImmutableArray<ISymbol> candidateSymbols, CandidateReason candidateReason, bool isSpreadParam = false)
+            : this(null, candidateSymbols, candidateReason, isSpreadParam)
         {
         }
 
-        internal SymbolInfo(ISymbol? symbol, ImmutableArray<ISymbol> candidateSymbols, CandidateReason candidateReason)
+        internal SymbolInfo(ISymbol? symbol, ImmutableArray<ISymbol> candidateSymbols, CandidateReason candidateReason, bool isSpreadParam = false)
             : this()
         {
             this.Symbol = symbol;
@@ -91,6 +96,7 @@ namespace Microsoft.CodeAnalysis
 #endif
 
             this.CandidateReason = candidateReason;
+            this.IsSpreadParam = isSpreadParam;
         }
 
         public override bool Equals(object? obj)

--- a/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Compilers/Core/Portable/PublicAPI.Unshipped.txt
@@ -9,6 +9,14 @@ Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsy
 Microsoft.CodeAnalysis.Diagnostics.CompilationWithAnalyzers.GetAnalysisResultAsync(Microsoft.CodeAnalysis.AdditionalText file, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.CodeAnalysis.Diagnostics.AnalysisResult>
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.get -> int
 Microsoft.CodeAnalysis.Diagnostics.Telemetry.AnalyzerTelemetryInfo.AdditionalFileActionsCount.set -> void
+Microsoft.CodeAnalysis.IParameterSymbol.IsSpread.get -> bool
+Microsoft.CodeAnalysis.SymbolInfo.IsSpreadParam.get -> bool
+Microsoft.CodeAnalysis.SymbolInfo.IsSpreadParam.set -> void
+Microsoft.CodeAnalysis.SymbolKind.Wrapped = 21 -> Microsoft.CodeAnalysis.SymbolKind
+Microsoft.CodeAnalysis.Symbols.SpreadParamSymbol
+Microsoft.CodeAnalysis.Symbols.SpreadParamSymbol.AsFieldSymbol.get -> Microsoft.CodeAnalysis.IFieldSymbol
+Microsoft.CodeAnalysis.Symbols.SpreadParamSymbol.ParamSymbol.get -> Microsoft.CodeAnalysis.ISymbol
+Microsoft.CodeAnalysis.Symbols.SpreadParamSymbol.SpreadParamSymbol(Microsoft.CodeAnalysis.ISymbol memberSymbol, Microsoft.CodeAnalysis.ISymbol paramSymbol) -> void
 Microsoft.CodeAnalysis.SyntaxNode.FindToken(int position, bool findInsideTrivia = false, bool findInsideSkippedTrivia = false) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxNode.GetLastToken(bool includeZeroWidth = false, bool includeSkipped = false, bool includeDirectives = false, bool includeDocumentationComments = false, System.Func<Microsoft.CodeAnalysis.SyntaxToken, bool> predicate = null) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxNode.HasErrors.get -> bool
@@ -21,6 +29,43 @@ Microsoft.CodeAnalysis.SyntaxNodeOrToken.WithLeadingTrivia(System.Collections.Ge
 Microsoft.CodeAnalysis.SyntaxToken.WithLeadingTrivia(System.Collections.Generic.IEnumerable<Microsoft.CodeAnalysis.SyntaxTrivia> trivia, int position = 0, int index = 0) -> Microsoft.CodeAnalysis.SyntaxToken
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
 Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.SyntaxTreeOptionsProvider() -> void
+Microsoft.CodeAnalysis.WrappedSymbol
+Microsoft.CodeAnalysis.WrappedSymbol.Accept(Microsoft.CodeAnalysis.SymbolVisitor visitor) -> void
+Microsoft.CodeAnalysis.WrappedSymbol.Accept<TResult>(Microsoft.CodeAnalysis.SymbolVisitor<TResult> visitor) -> TResult
+Microsoft.CodeAnalysis.WrappedSymbol.CanBeReferencedByName.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.ContainingAssembly.get -> Microsoft.CodeAnalysis.IAssemblySymbol
+Microsoft.CodeAnalysis.WrappedSymbol.ContainingModule.get -> Microsoft.CodeAnalysis.IModuleSymbol
+Microsoft.CodeAnalysis.WrappedSymbol.ContainingNamespace.get -> Microsoft.CodeAnalysis.INamespaceSymbol
+Microsoft.CodeAnalysis.WrappedSymbol.ContainingSymbol.get -> Microsoft.CodeAnalysis.ISymbol
+Microsoft.CodeAnalysis.WrappedSymbol.ContainingType.get -> Microsoft.CodeAnalysis.INamedTypeSymbol
+Microsoft.CodeAnalysis.WrappedSymbol.DeclaredAccessibility.get -> Microsoft.CodeAnalysis.Accessibility
+Microsoft.CodeAnalysis.WrappedSymbol.DeclaringSyntaxReferences.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SyntaxReference>
+Microsoft.CodeAnalysis.WrappedSymbol.Equals(Microsoft.CodeAnalysis.ISymbol other) -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.Equals(Microsoft.CodeAnalysis.ISymbol other, Microsoft.CodeAnalysis.SymbolEqualityComparer equalityComparer) -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.GetAttributes() -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.AttributeData>
+Microsoft.CodeAnalysis.WrappedSymbol.GetDocumentationCommentId() -> string
+Microsoft.CodeAnalysis.WrappedSymbol.GetDocumentationCommentXml(System.Globalization.CultureInfo preferredCulture = null, bool expandIncludes = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
+Microsoft.CodeAnalysis.WrappedSymbol.HasUnsupportedMetadata.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsAbstract.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsDefinition.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsExtern.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsImplicitlyDeclared.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsOverride.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsSealed.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsStatic.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.IsVirtual.get -> bool
+Microsoft.CodeAnalysis.WrappedSymbol.Language.get -> string
+Microsoft.CodeAnalysis.WrappedSymbol.Locations.get -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Location>
+Microsoft.CodeAnalysis.WrappedSymbol.MetadataName.get -> string
+Microsoft.CodeAnalysis.WrappedSymbol.Name.get -> string
+Microsoft.CodeAnalysis.WrappedSymbol.OriginalDefinition.get -> Microsoft.CodeAnalysis.ISymbol
+Microsoft.CodeAnalysis.WrappedSymbol.Symbol.get -> Microsoft.CodeAnalysis.ISymbol
+Microsoft.CodeAnalysis.WrappedSymbol.Symbol.set -> void
+Microsoft.CodeAnalysis.WrappedSymbol.ToDisplayParts(Microsoft.CodeAnalysis.SymbolDisplayFormat format = null) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SymbolDisplayPart>
+Microsoft.CodeAnalysis.WrappedSymbol.ToDisplayString(Microsoft.CodeAnalysis.SymbolDisplayFormat format = null) -> string
+Microsoft.CodeAnalysis.WrappedSymbol.ToMinimalDisplayParts(Microsoft.CodeAnalysis.SemanticModel semanticModel, int position, Microsoft.CodeAnalysis.SymbolDisplayFormat format = null) -> System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.SymbolDisplayPart>
+Microsoft.CodeAnalysis.WrappedSymbol.ToMinimalDisplayString(Microsoft.CodeAnalysis.SemanticModel semanticModel, int position, Microsoft.CodeAnalysis.SymbolDisplayFormat format = null) -> string
+Microsoft.CodeAnalysis.WrappedSymbol.WrappedSymbol(Microsoft.CodeAnalysis.ISymbol symbol) -> void
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.IsGenerated(Microsoft.CodeAnalysis.SyntaxTree tree) -> bool?
 abstract Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider.TryGetDiagnosticValue(Microsoft.CodeAnalysis.SyntaxTree tree, string diagnosticId, out Microsoft.CodeAnalysis.ReportDiagnostic severity) -> bool
 const Microsoft.CodeAnalysis.WellKnownMemberNames.TopLevelStatementsEntryPointMethodName = "<Main>$" -> string
@@ -28,5 +73,7 @@ const Microsoft.CodeAnalysis.WellKnownMemberNames.TopLevelStatementsEntryPointTy
 Microsoft.CodeAnalysis.CompilationOptions.SyntaxTreeOptionsProvider.get -> Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider
 Microsoft.CodeAnalysis.CompilationOptions.WithSyntaxTreeOptionsProvider(Microsoft.CodeAnalysis.SyntaxTreeOptionsProvider provider) -> Microsoft.CodeAnalysis.CompilationOptions
 Microsoft.CodeAnalysis.Operations.IPatternOperation.NarrowedType.get -> Microsoft.CodeAnalysis.ITypeSymbol
+override Microsoft.CodeAnalysis.Symbols.SpreadParamSymbol.Kind.get -> Microsoft.CodeAnalysis.SymbolKind
 virtual Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.RegisterAdditionalFileAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext> action) -> void
 virtual Microsoft.CodeAnalysis.Diagnostics.CompilationStartAnalysisContext.RegisterAdditionalFileAction(System.Action<Microsoft.CodeAnalysis.Diagnostics.AdditionalFileAnalysisContext> action) -> void
+virtual Microsoft.CodeAnalysis.WrappedSymbol.Kind.get -> Microsoft.CodeAnalysis.SymbolKind

--- a/src/Compilers/Core/Portable/Symbols/IParameterSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/IParameterSymbol.cs
@@ -30,6 +30,11 @@ namespace Microsoft.CodeAnalysis
         bool IsParams { get; }
 
         /// <summary>
+        /// Returns true if the parameter was declared as a spread input parameter.
+        /// </summary>
+        bool IsSpread { get; }
+
+        /// <summary>
         /// Returns true if the parameter is optional.
         /// </summary>
         bool IsOptional { get; }

--- a/src/Compilers/Core/Portable/Symbols/ISymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/ISymbol.cs
@@ -304,4 +304,115 @@ namespace Microsoft.CodeAnalysis
         /// <returns>True if the symbols are equivalent.</returns>
         bool Equals([NotNullWhen(returnValue: true)] ISymbol? other, SymbolEqualityComparer equalityComparer);
     }
+
+    public class WrappedSymbol : ISymbol
+    {
+        public WrappedSymbol(ISymbol symbol)
+        {
+            Symbol = symbol;
+        }
+
+        public ISymbol Symbol { get; protected set; }
+
+        public virtual SymbolKind Kind => Symbol.Kind;
+
+        public string Language => Symbol.Language;
+
+        public string Name => Symbol.Name;
+
+        public string MetadataName => Symbol.MetadataName;
+
+        public ISymbol ContainingSymbol => Symbol.ContainingSymbol;
+
+        public IAssemblySymbol ContainingAssembly => Symbol.ContainingAssembly;
+
+        public IModuleSymbol ContainingModule => Symbol.ContainingModule;
+
+        public INamedTypeSymbol ContainingType => Symbol.ContainingType;
+
+        public INamespaceSymbol ContainingNamespace => Symbol.ContainingNamespace;
+
+        public bool IsDefinition => Symbol.IsDefinition;
+
+        public bool IsStatic => Symbol.IsStatic;
+
+        public bool IsVirtual => Symbol.IsVirtual;
+
+        public bool IsOverride => Symbol.IsOverride;
+
+        public bool IsAbstract => Symbol.IsAbstract;
+
+        public bool IsSealed => Symbol.IsSealed;
+
+        public bool IsExtern => Symbol.IsExtern;
+
+        public bool IsImplicitlyDeclared => Symbol.IsImplicitlyDeclared;
+
+        public bool CanBeReferencedByName => Symbol.CanBeReferencedByName;
+
+        public ImmutableArray<Location> Locations => Symbol.Locations;
+
+        public ImmutableArray<SyntaxReference> DeclaringSyntaxReferences => Symbol.DeclaringSyntaxReferences;
+
+        public Accessibility DeclaredAccessibility => Symbol.DeclaredAccessibility;
+
+        public ISymbol OriginalDefinition => Symbol.OriginalDefinition;
+
+        public bool HasUnsupportedMetadata => Symbol.HasUnsupportedMetadata;
+
+        public void Accept(SymbolVisitor visitor)
+        {
+            Symbol.Accept(visitor);
+        }
+
+        public TResult Accept<TResult>(SymbolVisitor<TResult> visitor)
+        {
+            return Symbol.Accept(visitor);
+        }
+
+        public bool Equals([NotNullWhen(true)] ISymbol? other, SymbolEqualityComparer equalityComparer)
+        {
+            return Symbol.Equals(other, equalityComparer);
+        }
+
+        public bool Equals([AllowNull] ISymbol? other)
+        {
+            return Symbol.Equals(other);
+        }
+
+        public ImmutableArray<AttributeData> GetAttributes()
+        {
+            return Symbol.GetAttributes();
+        }
+
+        public string? GetDocumentationCommentId()
+        {
+            return Symbol.GetDocumentationCommentId();
+        }
+
+        public string? GetDocumentationCommentXml(CultureInfo? preferredCulture = null, bool expandIncludes = false, CancellationToken cancellationToken = default)
+        {
+            return Symbol.GetDocumentationCommentXml();
+        }
+
+        public ImmutableArray<SymbolDisplayPart> ToDisplayParts(SymbolDisplayFormat? format = null)
+        {
+            return Symbol.ToDisplayParts(format);
+        }
+
+        public string ToDisplayString(SymbolDisplayFormat? format = null)
+        {
+            return Symbol.ToDisplayString(format);
+        }
+
+        public ImmutableArray<SymbolDisplayPart> ToMinimalDisplayParts(SemanticModel semanticModel, int position, SymbolDisplayFormat? format = null)
+        {
+            return Symbol.ToMinimalDisplayParts(semanticModel, position, format);
+        }
+
+        public string ToMinimalDisplayString(SemanticModel semanticModel, int position, SymbolDisplayFormat? format = null)
+        {
+            return Symbol.ToMinimalDisplayString(semanticModel, position, format);
+        }
+    }
 }

--- a/src/Compilers/Core/Portable/Symbols/SpreadParamSymbol.cs
+++ b/src/Compilers/Core/Portable/Symbols/SpreadParamSymbol.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text;
+
+namespace Microsoft.CodeAnalysis.Symbols
+{
+    public class SpreadParamSymbol : WrappedSymbol, IFieldSymbol, IPropertySymbol
+    {
+        public SpreadParamSymbol(ISymbol memberSymbol, ISymbol paramSymbol)
+            : base(memberSymbol)
+        {
+            ParamSymbol = paramSymbol;
+        }
+
+        public ISymbol ParamSymbol { get; }
+
+        #region IPropertySymbol
+        private IPropertySymbol AsPropertySymbol => Symbol as IPropertySymbol;
+
+        bool IPropertySymbol.IsIndexer => AsPropertySymbol?.IsIndexer ?? false;
+
+        bool IPropertySymbol.IsReadOnly => AsPropertySymbol?.IsReadOnly ?? false;
+
+        bool IPropertySymbol.IsWriteOnly => AsPropertySymbol?.IsWriteOnly ?? false;
+
+        bool IPropertySymbol.IsWithEvents => AsPropertySymbol?.IsWithEvents ?? false;
+
+        bool IPropertySymbol.ReturnsByRef => AsPropertySymbol?.ReturnsByRef ?? false;
+
+        bool IPropertySymbol.ReturnsByRefReadonly => AsPropertySymbol?.ReturnsByRefReadonly ?? false;
+
+        RefKind IPropertySymbol.RefKind => AsPropertySymbol?.RefKind ?? RefKind.None;
+
+        ITypeSymbol IPropertySymbol.Type => AsPropertySymbol?.Type;
+
+        NullableAnnotation IPropertySymbol.NullableAnnotation => AsPropertySymbol?.NullableAnnotation ?? NullableAnnotation.None;
+
+        ImmutableArray<IParameterSymbol> IPropertySymbol.Parameters => AsPropertySymbol?.Parameters ?? ImmutableArray<IParameterSymbol>.Empty;
+
+        IMethodSymbol IPropertySymbol.GetMethod => AsPropertySymbol?.GetMethod;
+
+        IMethodSymbol IPropertySymbol.SetMethod => AsPropertySymbol?.SetMethod;
+
+        IPropertySymbol IPropertySymbol.OverriddenProperty => AsPropertySymbol?.OverriddenProperty;
+
+        ImmutableArray<IPropertySymbol> IPropertySymbol.ExplicitInterfaceImplementations => AsPropertySymbol?.ExplicitInterfaceImplementations ?? ImmutableArray<IPropertySymbol>.Empty;
+
+        ImmutableArray<CustomModifier> IPropertySymbol.RefCustomModifiers => AsPropertySymbol?.RefCustomModifiers ?? ImmutableArray<CustomModifier>.Empty;
+
+        ImmutableArray<CustomModifier> IPropertySymbol.TypeCustomModifiers => AsPropertySymbol?.TypeCustomModifiers ?? ImmutableArray<CustomModifier>.Empty;
+        #endregion
+
+        #region IFieldSymbol
+        private IFieldSymbol AsFieldSymbol => Symbol as IFieldSymbol;
+
+        ISymbol IFieldSymbol.AssociatedSymbol => AsFieldSymbol?.AssociatedSymbol;
+
+        bool IFieldSymbol.IsConst => AsFieldSymbol?.IsConst ?? false;
+
+        bool IFieldSymbol.IsReadOnly => AsFieldSymbol?.IsReadOnly ?? false;
+
+        bool IFieldSymbol.IsVolatile => AsFieldSymbol?.IsVolatile ?? false;
+
+        bool IFieldSymbol.IsFixedSizeBuffer => AsFieldSymbol?.IsFixedSizeBuffer ?? false;
+
+        ITypeSymbol IFieldSymbol.Type => AsFieldSymbol?.Type;
+
+        NullableAnnotation IFieldSymbol.NullableAnnotation => AsFieldSymbol?.NullableAnnotation ?? NullableAnnotation.None;
+
+        bool IFieldSymbol.HasConstantValue => AsFieldSymbol?.HasConstantValue ?? false;
+
+        object IFieldSymbol.ConstantValue => AsFieldSymbol?.ConstantValue;
+
+        ImmutableArray<CustomModifier> IFieldSymbol.CustomModifiers => AsFieldSymbol?.CustomModifiers ?? ImmutableArray<CustomModifier>.Empty;
+
+        IFieldSymbol IFieldSymbol.CorrespondingTupleField => AsFieldSymbol?.CorrespondingTupleField;
+
+        IFieldSymbol IFieldSymbol.OriginalDefinition => AsFieldSymbol?.OriginalDefinition;
+
+        IPropertySymbol IPropertySymbol.OriginalDefinition => throw new NotImplementedException();
+        #endregion
+    }
+}

--- a/src/Compilers/VisualBasic/Portable/Symbols/ParameterSymbol.vb
+++ b/src/Compilers/VisualBasic/Portable/Symbols/ParameterSymbol.vb
@@ -38,6 +38,12 @@ Namespace Microsoft.CodeAnalysis.VisualBasic.Symbols
             End Get
         End Property
 
+        Public ReadOnly Property IsSpread As Boolean Implements IParameterSymbol.IsSpread
+            Get
+                Return false
+            End Get
+        End Property
+
         ''' <summary>
         ''' Is this ByRef parameter.
         ''' </summary>

--- a/src/Features/Core/Portable/Completion/CompletionItem.cs
+++ b/src/Features/Core/Portable/Completion/CompletionItem.cs
@@ -98,6 +98,8 @@ namespace Microsoft.CodeAnalysis.Completion
 
         internal CompletionItemFlags Flags { get; set; }
 
+        internal ISymbol Symbol { get; set; }
+
         private CompletionItem(
             string displayText,
             string filterText,

--- a/src/Features/Core/Portable/PublicAPI.Unshipped.txt
+++ b/src/Features/Core/Portable/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-
+Microsoft.CodeAnalysis.Completion.CompletionItem.Tags.set -> void

--- a/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
+++ b/src/Workspaces/Core/Portable/CodeGeneration/Symbols/CodeGenerationParameterSymbol.cs
@@ -64,5 +64,7 @@ namespace Microsoft.CodeAnalysis.CodeGeneration
         public ImmutableArray<CustomModifier> CustomModifiers => ImmutableArray.Create<CustomModifier>();
 
         public bool IsDiscard => false;
+
+        public bool IsSpread => false;
     }
 }


### PR DESCRIPTION
Adds syntax concept for "spread" parameters for functions - allow declaring a type that acts as the parameters for a method - which can be used to easier write "library utils" where parameters are basically same as input to some class - like in "fluent syntax apis".

Enables following syntax:

```
class ComponentProps {
  public width int
  public height int  
}
class ButtonProps : ComponentProps {
  public text string
  public onClick fn()
}
class Button() {
  this(props ButtonProps) {
    Props = props
  }
  public Props ButtonProps { get; }
}

// button "config/factory" function 
button(props ...ButtonProps = null) Button {
  btn = new Button(props)
  return btn
}

// using this would be like:
button(width: 100, height: 30, onClick: {
  // notice "width" is not declared on the "button(...)" function ... it's a field of the "ButtonProps" ... but since it's used as a "spread param" ... we can declare the named args as if part of the function declaration
})
```